### PR TITLE
fix: Window rules should have singular `match` and `exclude` nodes

### DIFF
--- a/settings.nix
+++ b/settings.nix
@@ -1620,8 +1620,8 @@ with docs.lib; rec {
 
         window-rule = cfg:
           plain "window-rule" [
-            (map (leaf "matches") (filter-match cfg.matches))
-            (map (leaf "excludes") (filter-match cfg.excludes))
+            (map (leaf "match") (filter-match cfg.matches))
+            (map (leaf "exclude") (filter-match cfg.excludes))
             (nullable preset-widths "default-column-width" cfg.default-column-width)
             (nullable leaf "open-on-output" cfg.open-on-output)
             (nullable leaf "open-maximized" cfg.open-maximized)


### PR DESCRIPTION
Fixes the following error I've run into:
```
       error: builder for '/nix/store/wyx7z15i3h8m7wpi0j1rmxikf1q78naj-config.kdl.drv' failed with exit code 1;
       last 10 log lines:
       > Error: unexpected node `matches`
       >     Diagnostic severity: error
       >
       > Begin snippet for .attr-041r6j70w6v6dakqkzmwb899h71g2hibch7d14bbv9gy7bxhd5mp starting at line 113, column 1
       >
       > snippet line 113: spawn-at-startup "waybar"
       > snippet line 114: window-rule { matches app-id="firefox"; }
       >     label at line 114, columns 15 to 39: unexpected node
       > snippet line 115: window-rule { open-maximized true; }
       >
       For full logs, run 'nix log /nix/store/wyx7z15i3h8m7wpi0j1rmxikf1q78naj-config.kdl.drv'.
```
... when declaring the following window rule:
```nix
    window-rules = [
        {
          matches = [
            { app-id = "firefox"; }
          ];
          open-maximized = true;
        }
    ];
```