### PR TITLE
fix: renamed displayManager setting

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -407,7 +407,7 @@
               }
               (mkIf cfg.enable {
                 environment.systemPackages = [cfg.package];
-                services.xserver.displayManager.sessionPackages = [cfg.package];
+                services.displayManager.sessionPackages = [cfg.package];
                 xdg.portal = {
                   enable = true;
                   extraPortals = [pkgs.xdg-desktop-portal-gnome];


### PR DESCRIPTION
In https://github.com/NixOS/nixpkgs/pull/291913 the option `services.xserver.displayManager.sessionPackages` has been renamed to `services.displayManager.sessionPackages` to prepare for wayland without xserver enabled. This flake uses this option and breaks on the latest nixpkgs.
This change will likely not be breaking for much longer as backwards compatibility should be re-addded once https://github.com/NixOS/nixpkgs/pull/303186 is merged. But since niri is a wayland compositor, I believe it would make sense to make this change anyways.