### PR TITLE
Check if user has stylix.

### DIFF
--- a/stylix.nix
+++ b/stylix.nix
@@ -3,9 +3,12 @@
   config,
   ...
 }: let
-  inherit (lib) mkDefault mkIf;
+  inherit (lib) mkDefault mkEnableOption mkIf;
 in {
-  options.stylix.targets.niri.enable = (config.lib.stylix.mkEnableTarget) "niri" true;
+  options.stylix.targets.niri.enable =
+    if (config.lib ? stylix)
+    then (config.lib.stylix.mkEnableTarget) "niri" true
+    else mkEnableOption "niri";
 
   config = mkIf config.stylix.targets.niri.enable {
     programs.niri.settings = {


### PR DESCRIPTION
https://github.com/sodiboo/niri-flake/blob/cea8f80a5b8171e7c2b90b89c67ef4b28faa2bf9/stylix.nix#L10

Incorrectly assumes that all users on a NixOS system have stylix enabled.

This _ugly_ fix adds a dummy option if the module is not loaded for a user. Feel free to make it nicer.