### PR TITLE
kdl: fix null serialization

### DIFF
--- a/kdl.nix
+++ b/kdl.nix
@@ -32,7 +32,7 @@ with lib; let
     if v
     then "true"
     else "false";
-  serialize.null = "null";
+  serialize.null = _: "null";
 
   serialize.value = v: serialize.${builtins.typeOf v} v;
 


### PR DESCRIPTION
Serializing a value of `null` is currently broken, as `serialize.value` tries to call `serialize.null`, which is a string and not a function. This PR just turns `serialize.null` into a function to fix that.