### PR TITLE
Update NixOS version check

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -452,7 +452,7 @@
               }
               (mkIf cfg.enable {
                 services =
-                  if config.system.nixos.release == "24.05"
+                  if nixpkgs.lib.strings.versionAtLeast config.system.nixos.release "24.05"
                   then {
                     displayManager.sessionPackages = [cfg.package];
                   }


### PR DESCRIPTION
Since NixOS 24.05 was released, `nixos-unstable` is now on 24.11.

With the updated predicate, all future versions will use the `services.displayManager.sessionPackages` option.