### PR TITLE
Align with recent Stylix changes

### DIFF
--- a/stylix.nix
+++ b/stylix.nix
@@ -7,15 +7,15 @@
 in {
   options.stylix.targets.niri.enable = (config.lib.stylix.mkEnableTarget) "niri" true;
 
-  config = mkIf config.stylix.targets.niri.enable {
+  config = mkIf (config.stylix.enable && config.stylix.targets.niri.enable) {
     programs.niri.settings = {
       cursor.size = mkDefault config.stylix.cursor.size;
       cursor.theme = mkDefault config.stylix.cursor.name;
       layout.focus-ring.enable = mkDefault false;
-      layout.border = with config.lib.stylix.colors; {
+      layout.border = with config.lib.stylix.colors.withHashtag; {
         enable = mkDefault true;
-        active = mkDefault {color = "#${base0A}";};
-        inactive = mkDefault {color = "#${base03}";};
+        active = mkDefault {color = base0D;};
+        inactive = mkDefault {color = base03;};
       };
     };
   };


### PR DESCRIPTION
Hi! I've just been experimenting with different window managers, and I noticed that your Stylix module is out of sync with some of the latest changes.

1. `stylix.enable` was added in danth/stylix#244
2. The "standard" color for active windows was changed to `base0D` as part of danth/stylix#414

(Was surprised to find another project integrating with Stylix too)