### PR TITLE
fix incorrect type in `preset-column-widths` and `preset-window-heights` examples

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1461,9 +1461,9 @@ Example:
 ```nix
 {
   programs.niri.settings.layout.preset-column-widths = [
-    { proportion = 1./3.; }
-    { proportion = 1./2.; }
-    { proportion = 2./3.; }
+    { proportion = 1. / 3.; }
+    { proportion = 1. / 2.; }
+    { proportion = 2. / 3.; }
 
     # { fixed = 1920; }
   ];
@@ -1498,9 +1498,9 @@ Example:
 ```nix
 {
   programs.niri.settings.layout.preset-window-heights = [
-    { proportion = 1./3.; }
-    { proportion = 1./2.; }
-    { proportion = 2./3.; }
+    { proportion = 1. / 3.; }
+    { proportion = 1. / 2.; }
+    { proportion = 2. / 3.; }
 
     # { fixed = 1080; }
   ];

--- a/settings.nix
+++ b/settings.nix
@@ -1275,9 +1275,9 @@ with docs.lib; {
                   ```nix
                   {
                     programs.niri.settings.layout.preset-column-widths = [
-                      { proportion = 1./3.; }
-                      { proportion = 1./2.; }
-                      { proportion = 2./3.; }
+                      { proportion = 1. / 3.; }
+                      { proportion = 1. / 2.; }
+                      { proportion = 2. / 3.; }
 
                       # { fixed = 1920; }
                     ];
@@ -1298,9 +1298,9 @@ with docs.lib; {
                   ```nix
                   {
                     programs.niri.settings.layout.preset-window-heights = [
-                      { proportion = 1./3.; }
-                      { proportion = 1./2.; }
-                      { proportion = 2./3.; }
+                      { proportion = 1. / 3.; }
+                      { proportion = 1. / 2.; }
+                      { proportion = 2. / 3.; }
 
                       # { fixed = 1080; }
                     ];


### PR DESCRIPTION
This was causing issues for me while rebuilding because `1./2.` is of type `path`. Corrected it to `1. / 2.` which is of type `float`.