### PR TITLE
set environment variable in default config to fix issues with Java ap…

### DIFF
--- a/settings.nix
+++ b/settings.nix
@@ -2457,7 +2457,10 @@
         (flag' "skip-at-startup" cfg.hotkey-overlay.skip-at-startup)
       ])
 
-      (plain "environment" (lib.mapAttrsToList leaf cfg.environment))
+      (plain "environment" (lib.mapAttrsToList leaf (cfg.environment // {
+        _JAVA_AWT_WM_NONREPARENTING = "1"; # https://github.com/YaLTeR/niri/wiki/Application-Issues#ghidra
+      })))
+
       (plain "binds" (lib.mapAttrsToList bind cfg.binds))
       (nullable plain "switch-events" (
         let


### PR DESCRIPTION
This fix is mentioned in the Wiki under "Application Issues" https://github.com/YaLTeR/niri/wiki/Application-Issues#ghidra.

I saw that the fix for [Wezterm](https://github.com/YaLTeR/niri/wiki/Application-Issues#wezterm) is already added to the default config, and therefore I though that the fix for this issue should be added aswell to improve the Out of Box experience.

If this is not the right place to introduce the environment variable please let me know. I could not figure out if it should be part of the `nixosModules` or `homeModules`.