### PR TITLE
add shell completions for niri

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
       patches ? [],
       rustPlatform,
       pkg-config,
+      installShellFiles,
       wayland,
       systemdLibs,
       eudev,
@@ -82,6 +83,7 @@
       withDinit ? false,
       withScreencastSupport ? true,
       withSystemd ? true,
+      hasShellCompletion ? false,
       fetchzip,
       runCommand,
     }: let
@@ -118,6 +120,7 @@
         nativeBuildInputs = [
           pkg-config
           rustPlatform.bindgenHook
+          installShellFiles
         ];
 
         buildInputs =
@@ -190,6 +193,14 @@
           ''
           + nixpkgs.lib.optionalString withDinit ''
             install -Dm0644 resources/dinit/niri{,-shutdown} -t $out/lib/dinit.d/user
+          ''
+          # install shell completions
+          + nixpkgs.lib.optionalString hasShellCompletion
+          ''
+            installShellCompletion --cmd niri \
+              --bash <($out/bin/niri completions bash) \
+              --zsh <($out/bin/niri completions zsh) \
+              --fish <($out/bin/niri completions fish)
           '';
 
         postFixup = ''
@@ -280,6 +291,7 @@
       };
       niri-unstable = pkgs.callPackage make-niri {
         src = inputs.niri-unstable;
+        hasShellCompletion = true;
       };
       xwayland-satellite-stable = pkgs.callPackage make-xwayland-satellite {
         src = inputs.xwayland-satellite-stable;


### PR DESCRIPTION
as the title, i find the master `niri` supports to generate shell completions. so i add a `postInstall` step to install shell completions. and because stable `niri` doesn't support this, i add `hasShellCompletion` arg in `make-niri` function temporarily, until stable `niri` supporting the feature.