### PR TITLE
get rid of missing description warnings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -383,6 +383,7 @@
         package = nixpkgs.lib.mkOption {
           type = nixpkgs.lib.types.package;
           default = (make-package-set pkgs).niri-stable;
+          description = "The niri package to use.";
         };
       };
 
@@ -417,6 +418,7 @@
         package = nixpkgs.lib.mkOption {
           type = nixpkgs.lib.types.package;
           default = (make-package-set pkgs).niri-stable;
+          description = "The niri package to use.";
         };
       };
 

--- a/flake.nix
+++ b/flake.nix
@@ -422,10 +422,9 @@
         };
       };
 
-      options.niri-flake.cache.enable = nixpkgs.lib.mkOption {
-        type = nixpkgs.lib.types.bool;
-        default = true;
-      };
+      options.niri-flake.cache.enable =
+        nixpkgs.lib.mkEnableOption "the niri-flake binary cache"
+        // {default = true;};
 
       config = nixpkgs.lib.mkMerge [
         (nixpkgs.lib.mkIf config.niri-flake.cache.enable {


### PR DESCRIPTION
some options were missing descriptions, which caused warnings, which without `documentation.nixos.options.warningsAreErrors = false;` were errors and stopped my build

the docs were added by the pre commit hook