### PR TITLE
Remove checks for outdate nixos versions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -434,34 +434,17 @@
           };
         })
         (nixpkgs.lib.mkIf cfg.enable {
-          environment.systemPackages = [pkgs.xdg-utils];
+          environment.systemPackages = [pkgs.xdg-utils cfg.package];
           xdg = {
             autostart.enable = nixpkgs.lib.mkDefault true;
             menus.enable = nixpkgs.lib.mkDefault true;
             mime.enable = nixpkgs.lib.mkDefault true;
             icons.enable = nixpkgs.lib.mkDefault true;
           };
-        })
-        (nixpkgs.lib.mkIf cfg.enable {
-          services =
-            if nixpkgs.lib.strings.versionAtLeast config.system.nixos.release "24.05"
-            then {
-              displayManager.sessionPackages = [cfg.package];
-            }
-            else {
-              xserver.displayManager.sessionPackages = [cfg.package];
-            };
-          hardware =
-            if nixpkgs.lib.strings.versionAtLeast config.system.nixos.release "24.11"
-            then {
-              graphics.enable = nixpkgs.lib.mkDefault true;
-            }
-            else {
-              opengl.enable = nixpkgs.lib.mkDefault true;
-            };
-        })
-        (nixpkgs.lib.mkIf cfg.enable {
-          environment.systemPackages = [cfg.package];
+
+          services.displayManager.sessionPackages = [cfg.package];
+          hardware.graphics.enable = nixpkgs.lib.mkDefault true;
+
           xdg.portal = {
             enable = true;
             extraPortals = nixpkgs.lib.mkIf (


### PR DESCRIPTION
The previous version using just if-then-else infinite recursed for me.
I wish I could tell you exactly why, but I'm doing quite a lot of esoteric things in my config
these days, so I couldn't really figure out why this happens for me but seemingly for no
one else.

I think either way using mkIf is the preferred way to conditionally set options in NixOs as it
is generally safer from recursion.
