### PR TITLE
nixosModule.niri: don't include xdg-utils if niri is disabled

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -433,7 +433,7 @@
             trusted-public-keys = ["niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964="];
           };
         })
-        {
+        (nixpkgs.lib.mkIf cfg.enable {
           environment.systemPackages = [pkgs.xdg-utils];
           xdg = {
             autostart.enable = nixpkgs.lib.mkDefault true;
@@ -441,7 +441,7 @@
             mime.enable = nixpkgs.lib.mkDefault true;
             icons.enable = nixpkgs.lib.mkDefault true;
           };
-        }
+        })
         (nixpkgs.lib.mkIf cfg.enable {
           services =
             if nixpkgs.lib.strings.versionAtLeast config.system.nixos.release "24.05"


### PR DESCRIPTION
finally found out why my server's closure suddenly included `xdg-utils`. The flake should not touch *any* options if `programs.niri.enable = true` in my opinion.