### PR TITLE
settings.nix: Add overview.zoom and overview.backdrop-color

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -714,7 +714,25 @@ order for the named workspaces.
 The name of the output the workspace should be assigned to.
 
 
-<!-- sorting key: programs.niri.settings.h.input.focus-follows-mouse.enable -->
+<!-- sorting key: programs.niri.settings.h.overview.backdrop-color -->
+## `programs.niri.settings.overview.backdrop-color`
+- type: `null or string`
+- default: `null`
+
+Set the backdrop color behind workspaces in the overview. The backdrop is also visible between workspaces when switching.
+
+The alpha channel for this color will be ignored.
+
+
+<!-- sorting key: programs.niri.settings.h.overview.zoom -->
+## `programs.niri.settings.overview.zoom`
+- type: `null or floating point number or signed integer`
+- default: `null`
+
+Control how much the workspaces zoom out in the overview. zoom ranges from 0 to 0.75 where lower values make everything smaller.
+
+
+<!-- sorting key: programs.niri.settings.i.input.focus-follows-mouse.enable -->
 ## `programs.niri.settings.input.focus-follows-mouse.enable`
 - type: `boolean`
 - default: `false`
@@ -722,7 +740,7 @@ The name of the output the workspace should be assigned to.
 Whether to focus the window under the mouse when the mouse moves.
 
 
-<!-- sorting key: programs.niri.settings.h.input.focus-follows-mouse.max-scroll-amount -->
+<!-- sorting key: programs.niri.settings.i.input.focus-follows-mouse.max-scroll-amount -->
 ## `programs.niri.settings.input.focus-follows-mouse.max-scroll-amount`
 - type: `null or string`
 - default: `null`
@@ -730,7 +748,7 @@ Whether to focus the window under the mouse when the mouse moves.
 The maximum proportion of the screen to scroll at a time
 
 
-<!-- sorting key: programs.niri.settings.h.input.keyboard.repeat-delay -->
+<!-- sorting key: programs.niri.settings.i.input.keyboard.repeat-delay -->
 ## `programs.niri.settings.input.keyboard.repeat-delay`
 - type: `signed integer`
 - default: `600`
@@ -738,7 +756,7 @@ The maximum proportion of the screen to scroll at a time
 The delay in milliseconds before a key starts repeating.
 
 
-<!-- sorting key: programs.niri.settings.h.input.keyboard.repeat-rate -->
+<!-- sorting key: programs.niri.settings.i.input.keyboard.repeat-rate -->
 ## `programs.niri.settings.input.keyboard.repeat-rate`
 - type: `signed integer`
 - default: `25`
@@ -746,7 +764,7 @@ The delay in milliseconds before a key starts repeating.
 The rate in characters per second at which a key repeats.
 
 
-<!-- sorting key: programs.niri.settings.h.input.keyboard.track-layout -->
+<!-- sorting key: programs.niri.settings.i.input.keyboard.track-layout -->
 ## `programs.niri.settings.input.keyboard.track-layout`
 - type: `one of "global", "window"`
 - default: `"global"`
@@ -756,7 +774,7 @@ The keyboard layout can be remembered per `"window"`, such that when you switch 
 By default, there is only one `"global"` keyboard layout and changing it in any window will affect the keyboard layout used in all other windows too.
 
 
-<!-- sorting key: programs.niri.settings.h.input.keyboard.xkb -->
+<!-- sorting key: programs.niri.settings.i.input.keyboard.xkb -->
 ## `programs.niri.settings.input.keyboard.xkb`
 
 
@@ -766,7 +784,7 @@ Further reading:
 - [`smithay::wayland::seat::XkbConfig`](https://docs.rs/smithay/latest/smithay/wayland/seat/struct.XkbConfig.html)
 
 
-<!-- sorting key: programs.niri.settings.h.input.keyboard.xkb.a.file -->
+<!-- sorting key: programs.niri.settings.i.input.keyboard.xkb.a.file -->
 ## `programs.niri.settings.input.keyboard.xkb.file`
 - type: `null or string`
 - default: `null`
@@ -774,7 +792,7 @@ Further reading:
 Path to a `.xkb` keymap file. If set, this file will be used to configure libxkbcommon, and all other options will be ignored.
 
 
-<!-- sorting key: programs.niri.settings.h.input.keyboard.xkb.b.layout -->
+<!-- sorting key: programs.niri.settings.i.input.keyboard.xkb.b.layout -->
 ## `programs.niri.settings.input.keyboard.xkb.layout`
 - type: `string`
 - default: `""`
@@ -787,7 +805,7 @@ If this is set to an empty string, the layout will be read from the `XKB_DEFAULT
 
 
 
-<!-- sorting key: programs.niri.settings.h.input.keyboard.xkb.b.model -->
+<!-- sorting key: programs.niri.settings.i.input.keyboard.xkb.b.model -->
 ## `programs.niri.settings.input.keyboard.xkb.model`
 - type: `string`
 - default: `""`
@@ -800,7 +818,7 @@ If this is set to an empty string, the model will be read from the `XKB_DEFAULT_
 
 
 
-<!-- sorting key: programs.niri.settings.h.input.keyboard.xkb.b.options -->
+<!-- sorting key: programs.niri.settings.i.input.keyboard.xkb.b.options -->
 ## `programs.niri.settings.input.keyboard.xkb.options`
 - type: `null or string`
 - default: `null`
@@ -815,7 +833,7 @@ If this is set to null, the options will be read from the `XKB_DEFAULT_OPTIONS` 
 
 
 
-<!-- sorting key: programs.niri.settings.h.input.keyboard.xkb.b.rules -->
+<!-- sorting key: programs.niri.settings.i.input.keyboard.xkb.b.rules -->
 ## `programs.niri.settings.input.keyboard.xkb.rules`
 - type: `string`
 - default: `""`
@@ -828,7 +846,7 @@ If this is set to an empty string, the rules will be read from the `XKB_DEFAULT_
 
 
 
-<!-- sorting key: programs.niri.settings.h.input.keyboard.xkb.b.variant -->
+<!-- sorting key: programs.niri.settings.i.input.keyboard.xkb.b.variant -->
 ## `programs.niri.settings.input.keyboard.xkb.variant`
 - type: `string`
 - default: `""`
@@ -841,7 +859,7 @@ If this is set to an empty string, the variant will be read from the `XKB_DEFAUL
 
 
 
-<!-- sorting key: programs.niri.settings.h.input.mouse.accel-profile -->
+<!-- sorting key: programs.niri.settings.i.input.mouse.accel-profile -->
 ## `programs.niri.settings.input.mouse.accel-profile`
 - type: `null or one of "adaptive", "flat"`
 - default: `null`
@@ -850,7 +868,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration-profiles
 
 
-<!-- sorting key: programs.niri.settings.h.input.mouse.accel-speed -->
+<!-- sorting key: programs.niri.settings.i.input.mouse.accel-speed -->
 ## `programs.niri.settings.input.mouse.accel-speed`
 - type: `floating point number`
 - default: `0.000000`
@@ -859,13 +877,13 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#pointer-acceleration
 
 
-<!-- sorting key: programs.niri.settings.h.input.mouse.enable -->
+<!-- sorting key: programs.niri.settings.i.input.mouse.enable -->
 ## `programs.niri.settings.input.mouse.enable`
 - type: `boolean`
 - default: `true`
 
 
-<!-- sorting key: programs.niri.settings.h.input.mouse.left-handed -->
+<!-- sorting key: programs.niri.settings.i.input.mouse.left-handed -->
 ## `programs.niri.settings.input.mouse.left-handed`
 - type: `boolean`
 - default: `false`
@@ -877,7 +895,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#left-handed-mode
 
 
-<!-- sorting key: programs.niri.settings.h.input.mouse.middle-emulation -->
+<!-- sorting key: programs.niri.settings.i.input.mouse.middle-emulation -->
 ## `programs.niri.settings.input.mouse.middle-emulation`
 - type: `boolean`
 - default: `false`
@@ -889,7 +907,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/middle-button-emulation.html#middle-button-emulation
 
 
-<!-- sorting key: programs.niri.settings.h.input.mouse.natural-scroll -->
+<!-- sorting key: programs.niri.settings.i.input.mouse.natural-scroll -->
 ## `programs.niri.settings.input.mouse.natural-scroll`
 - type: `boolean`
 - default: `false`
@@ -901,7 +919,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#natural-scrolling-vs-traditional-scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.mouse.scroll-button -->
+<!-- sorting key: programs.niri.settings.i.input.mouse.scroll-button -->
 ## `programs.niri.settings.input.mouse.scroll-button`
 - type: `null or signed integer`
 - default: `null`
@@ -912,7 +930,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#on-button-scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.mouse.scroll-factor -->
+<!-- sorting key: programs.niri.settings.i.input.mouse.scroll-factor -->
 ## `programs.niri.settings.input.mouse.scroll-factor`
 - type: `null or floating point number`
 - default: `null`
@@ -922,7 +940,7 @@ For all scroll events triggered by a wheel source, the scroll distance is multip
 This is not a libinput property, but rather a niri-specific one.
 
 
-<!-- sorting key: programs.niri.settings.h.input.mouse.scroll-method -->
+<!-- sorting key: programs.niri.settings.i.input.mouse.scroll-method -->
 ## `programs.niri.settings.input.mouse.scroll-method`
 - type: `null or one of "no-scroll", "two-finger", "edge", "on-button-down"`
 - default: `null`
@@ -934,7 +952,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.power-key-handling.enable -->
+<!-- sorting key: programs.niri.settings.i.input.power-key-handling.enable -->
 ## `programs.niri.settings.input.power-key-handling.enable`
 - type: `boolean`
 - default: `true`
@@ -944,7 +962,7 @@ By default, niri will take over the power button to make it sleep instead of pow
 You can disable this behaviour if you prefer to configure the power button elsewhere.
 
 
-<!-- sorting key: programs.niri.settings.h.input.tablet.calibration-matrix -->
+<!-- sorting key: programs.niri.settings.i.input.tablet.calibration-matrix -->
 ## `programs.niri.settings.input.tablet.calibration-matrix`
 - type: `null or (2x3 matrix)`
 - default: `null`
@@ -970,13 +988,13 @@ Further reading:
 - [rustdoc because libinput's web docs are an eyesore](https://smithay.github.io/smithay/input/struct.Device.html#method.config_calibration_set_matrix)
 
 
-<!-- sorting key: programs.niri.settings.h.input.tablet.enable -->
+<!-- sorting key: programs.niri.settings.i.input.tablet.enable -->
 ## `programs.niri.settings.input.tablet.enable`
 - type: `boolean`
 - default: `true`
 
 
-<!-- sorting key: programs.niri.settings.h.input.tablet.left-handed -->
+<!-- sorting key: programs.niri.settings.i.input.tablet.left-handed -->
 ## `programs.niri.settings.input.tablet.left-handed`
 - type: `boolean`
 - default: `false`
@@ -988,19 +1006,19 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#left-handed-mode
 
 
-<!-- sorting key: programs.niri.settings.h.input.tablet.map-to-output -->
+<!-- sorting key: programs.niri.settings.i.input.tablet.map-to-output -->
 ## `programs.niri.settings.input.tablet.map-to-output`
 - type: `null or string`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.h.input.touch.map-to-output -->
+<!-- sorting key: programs.niri.settings.i.input.touch.map-to-output -->
 ## `programs.niri.settings.input.touch.map-to-output`
 - type: `null or string`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.accel-profile -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.accel-profile -->
 ## `programs.niri.settings.input.touchpad.accel-profile`
 - type: `null or one of "adaptive", "flat"`
 - default: `null`
@@ -1009,7 +1027,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration-profiles
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.accel-speed -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.accel-speed -->
 ## `programs.niri.settings.input.touchpad.accel-speed`
 - type: `floating point number`
 - default: `0.000000`
@@ -1018,7 +1036,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#pointer-acceleration
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.click-method -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.click-method -->
 ## `programs.niri.settings.input.touchpad.click-method`
 - type: `null or one of "button-areas", "clickfinger"`
 - default: `null`
@@ -1036,7 +1054,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/clickpad-softbuttons.html#clickpad-software-button-behavior
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.disabled-on-external-mouse -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.disabled-on-external-mouse -->
 ## `programs.niri.settings.input.touchpad.disabled-on-external-mouse`
 - type: `boolean`
 - default: `false`
@@ -1047,7 +1065,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#send-events-mode
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.drag-lock -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.drag-lock -->
 ## `programs.niri.settings.input.touchpad.drag-lock`
 - type: `boolean`
 - default: `false`
@@ -1066,7 +1084,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/tapping.html#tap-and-drag
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.dwt -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.dwt -->
 ## `programs.niri.settings.input.touchpad.dwt`
 - type: `boolean`
 - default: `false`
@@ -1078,7 +1096,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/palm-detection.html#disable-while-typing
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.dwtp -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.dwtp -->
 ## `programs.niri.settings.input.touchpad.dwtp`
 - type: `boolean`
 - default: `false`
@@ -1090,13 +1108,13 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/palm-detection.html#disable-while-trackpointing
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.enable -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.enable -->
 ## `programs.niri.settings.input.touchpad.enable`
 - type: `boolean`
 - default: `true`
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.left-handed -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.left-handed -->
 ## `programs.niri.settings.input.touchpad.left-handed`
 - type: `boolean`
 - default: `false`
@@ -1108,7 +1126,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#left-handed-mode
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.middle-emulation -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.middle-emulation -->
 ## `programs.niri.settings.input.touchpad.middle-emulation`
 - type: `boolean`
 - default: `false`
@@ -1120,7 +1138,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/middle-button-emulation.html#middle-button-emulation
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.natural-scroll -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.natural-scroll -->
 ## `programs.niri.settings.input.touchpad.natural-scroll`
 - type: `boolean`
 - default: `true`
@@ -1132,7 +1150,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#natural-scrolling-vs-traditional-scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.scroll-button -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.scroll-button -->
 ## `programs.niri.settings.input.touchpad.scroll-button`
 - type: `null or signed integer`
 - default: `null`
@@ -1143,7 +1161,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#on-button-scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.scroll-factor -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.scroll-factor -->
 ## `programs.niri.settings.input.touchpad.scroll-factor`
 - type: `null or floating point number`
 - default: `null`
@@ -1153,7 +1171,7 @@ For all scroll events triggered by a finger source, the scroll distance is multi
 This is not a libinput property, but rather a niri-specific one.
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.scroll-method -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.scroll-method -->
 ## `programs.niri.settings.input.touchpad.scroll-method`
 - type: `null or one of "no-scroll", "two-finger", "edge", "on-button-down"`
 - default: `null`
@@ -1165,7 +1183,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.tap -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.tap -->
 ## `programs.niri.settings.input.touchpad.tap`
 - type: `boolean`
 - default: `true`
@@ -1177,7 +1195,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/tapping.html#tap-to-click-behaviour
 
 
-<!-- sorting key: programs.niri.settings.h.input.touchpad.tap-button-map -->
+<!-- sorting key: programs.niri.settings.i.input.touchpad.tap-button-map -->
 ## `programs.niri.settings.input.touchpad.tap-button-map`
 - type: `null or one of "left-middle-right", "left-right-middle"`
 - default: `null`
@@ -1188,7 +1206,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#tap-to-click
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackball.accel-profile -->
+<!-- sorting key: programs.niri.settings.i.input.trackball.accel-profile -->
 ## `programs.niri.settings.input.trackball.accel-profile`
 - type: `null or one of "adaptive", "flat"`
 - default: `null`
@@ -1197,7 +1215,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration-profiles
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackball.accel-speed -->
+<!-- sorting key: programs.niri.settings.i.input.trackball.accel-speed -->
 ## `programs.niri.settings.input.trackball.accel-speed`
 - type: `floating point number`
 - default: `0.000000`
@@ -1206,13 +1224,13 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#pointer-acceleration
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackball.enable -->
+<!-- sorting key: programs.niri.settings.i.input.trackball.enable -->
 ## `programs.niri.settings.input.trackball.enable`
 - type: `boolean`
 - default: `true`
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackball.left-handed -->
+<!-- sorting key: programs.niri.settings.i.input.trackball.left-handed -->
 ## `programs.niri.settings.input.trackball.left-handed`
 - type: `boolean`
 - default: `false`
@@ -1224,7 +1242,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#left-handed-mode
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackball.middle-emulation -->
+<!-- sorting key: programs.niri.settings.i.input.trackball.middle-emulation -->
 ## `programs.niri.settings.input.trackball.middle-emulation`
 - type: `boolean`
 - default: `false`
@@ -1236,7 +1254,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/middle-button-emulation.html#middle-button-emulation
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackball.natural-scroll -->
+<!-- sorting key: programs.niri.settings.i.input.trackball.natural-scroll -->
 ## `programs.niri.settings.input.trackball.natural-scroll`
 - type: `boolean`
 - default: `false`
@@ -1248,7 +1266,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#natural-scrolling-vs-traditional-scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackball.scroll-button -->
+<!-- sorting key: programs.niri.settings.i.input.trackball.scroll-button -->
 ## `programs.niri.settings.input.trackball.scroll-button`
 - type: `null or signed integer`
 - default: `null`
@@ -1259,7 +1277,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#on-button-scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackball.scroll-method -->
+<!-- sorting key: programs.niri.settings.i.input.trackball.scroll-method -->
 ## `programs.niri.settings.input.trackball.scroll-method`
 - type: `null or one of "no-scroll", "two-finger", "edge", "on-button-down"`
 - default: `null`
@@ -1271,7 +1289,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackpoint.accel-profile -->
+<!-- sorting key: programs.niri.settings.i.input.trackpoint.accel-profile -->
 ## `programs.niri.settings.input.trackpoint.accel-profile`
 - type: `null or one of "adaptive", "flat"`
 - default: `null`
@@ -1280,7 +1298,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/pointer-acceleration.html#pointer-acceleration-profiles
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackpoint.accel-speed -->
+<!-- sorting key: programs.niri.settings.i.input.trackpoint.accel-speed -->
 ## `programs.niri.settings.input.trackpoint.accel-speed`
 - type: `floating point number`
 - default: `0.000000`
@@ -1289,13 +1307,13 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#pointer-acceleration
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackpoint.enable -->
+<!-- sorting key: programs.niri.settings.i.input.trackpoint.enable -->
 ## `programs.niri.settings.input.trackpoint.enable`
 - type: `boolean`
 - default: `true`
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackpoint.left-handed -->
+<!-- sorting key: programs.niri.settings.i.input.trackpoint.left-handed -->
 ## `programs.niri.settings.input.trackpoint.left-handed`
 - type: `boolean`
 - default: `false`
@@ -1307,7 +1325,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/configuration.html#left-handed-mode
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackpoint.middle-emulation -->
+<!-- sorting key: programs.niri.settings.i.input.trackpoint.middle-emulation -->
 ## `programs.niri.settings.input.trackpoint.middle-emulation`
 - type: `boolean`
 - default: `false`
@@ -1319,7 +1337,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/middle-button-emulation.html#middle-button-emulation
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackpoint.natural-scroll -->
+<!-- sorting key: programs.niri.settings.i.input.trackpoint.natural-scroll -->
 ## `programs.niri.settings.input.trackpoint.natural-scroll`
 - type: `boolean`
 - default: `false`
@@ -1331,7 +1349,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#natural-scrolling-vs-traditional-scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackpoint.scroll-button -->
+<!-- sorting key: programs.niri.settings.i.input.trackpoint.scroll-button -->
 ## `programs.niri.settings.input.trackpoint.scroll-button`
 - type: `null or signed integer`
 - default: `null`
@@ -1342,7 +1360,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#on-button-scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.trackpoint.scroll-method -->
+<!-- sorting key: programs.niri.settings.i.input.trackpoint.scroll-method -->
 ## `programs.niri.settings.input.trackpoint.scroll-method`
 - type: `null or one of "no-scroll", "two-finger", "edge", "on-button-down"`
 - default: `null`
@@ -1354,7 +1372,7 @@ Further reading:
 - https://wayland.freedesktop.org/libinput/doc/latest/scrolling.html#scrolling
 
 
-<!-- sorting key: programs.niri.settings.h.input.warp-mouse-to-focus -->
+<!-- sorting key: programs.niri.settings.i.input.warp-mouse-to-focus -->
 ## `programs.niri.settings.input.warp-mouse-to-focus`
 - type: `boolean`
 - default: `false`
@@ -1362,7 +1380,7 @@ Further reading:
 Whether to warp the mouse to the focused window when switching focus.
 
 
-<!-- sorting key: programs.niri.settings.h.input.workspace-auto-back-and-forth -->
+<!-- sorting key: programs.niri.settings.i.input.workspace-auto-back-and-forth -->
 ## `programs.niri.settings.input.workspace-auto-back-and-forth`
 - type: `boolean`
 - default: `false`
@@ -1372,12 +1390,12 @@ When invoking `focus-workspace` to switch to a workspace by index, if the worksp
 Of note is that it does not switch to the previous *index*, but the previous *workspace*. That means you can reorder workspaces inbetween these actions, and it will still take you to the actual same workspace you came from.
 
 
-<!-- sorting key: programs.niri.settings.i.outputs -->
+<!-- sorting key: programs.niri.settings.j.outputs -->
 ## `programs.niri.settings.outputs`
 - type: `attribute set of (submodule)`
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.backdrop-color -->
+<!-- sorting key: programs.niri.settings.j.outputs.backdrop-color -->
 ## `programs.niri.settings.outputs.<name>.backdrop-color`
 - type: `null or string`
 - default: `null`
@@ -1393,7 +1411,7 @@ Of note is that it does not switch to the previous *index*, but the previous *wo
 The backdrop color that niri draws for this output. This is visible between workspaces or in the overview.
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.background-color -->
+<!-- sorting key: programs.niri.settings.j.outputs.background-color -->
 ## `programs.niri.settings.outputs.<name>.background-color`
 - type: `null or string`
 - default: `null`
@@ -1401,13 +1419,13 @@ The backdrop color that niri draws for this output. This is visible between work
 The background color of this output. This is equivalent to launching `swaybg -c <color>` on that output, but is handled by the compositor itself for solid colors.
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.enable -->
+<!-- sorting key: programs.niri.settings.j.outputs.enable -->
 ## `programs.niri.settings.outputs.<name>.enable`
 - type: `boolean`
 - default: `true`
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.mode -->
+<!-- sorting key: programs.niri.settings.j.outputs.mode -->
 ## `programs.niri.settings.outputs.<name>.mode`
 - type: `null or (submodule)`
 - default: `null`
@@ -1419,12 +1437,12 @@ By default, when this is null, niri will automatically pick a mode for you.
 If this is set to an invalid mode (i.e unsupported by this output), niri will act as if it is unset and pick one for you.
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.mode.height -->
+<!-- sorting key: programs.niri.settings.j.outputs.mode.height -->
 ## `programs.niri.settings.outputs.<name>.mode.height`
 - type: `signed integer`
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.mode.refresh -->
+<!-- sorting key: programs.niri.settings.j.outputs.mode.refresh -->
 ## `programs.niri.settings.outputs.<name>.mode.refresh`
 - type: `null or floating point number`
 - default: `null`
@@ -1432,12 +1450,12 @@ If this is set to an invalid mode (i.e unsupported by this output), niri will ac
 The refresh rate of this output. When this is null, but the resolution is set, niri will automatically pick the highest available refresh rate.
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.mode.width -->
+<!-- sorting key: programs.niri.settings.j.outputs.mode.width -->
 ## `programs.niri.settings.outputs.<name>.mode.width`
 - type: `signed integer`
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.position -->
+<!-- sorting key: programs.niri.settings.j.outputs.position -->
 ## `programs.niri.settings.outputs.<name>.position`
 - type: `null or (submodule)`
 - default: `null`
@@ -1455,17 +1473,17 @@ For example, a 3840x2160 output with scale 2.0 will have a logical size of 1920x
 If the position is unset or multiple outputs overlap, niri will instead place the output automatically.
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.position.x -->
+<!-- sorting key: programs.niri.settings.j.outputs.position.x -->
 ## `programs.niri.settings.outputs.<name>.position.x`
 - type: `signed integer`
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.position.y -->
+<!-- sorting key: programs.niri.settings.j.outputs.position.y -->
 ## `programs.niri.settings.outputs.<name>.position.y`
 - type: `signed integer`
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.scale -->
+<!-- sorting key: programs.niri.settings.j.outputs.scale -->
 ## `programs.niri.settings.outputs.<name>.scale`
 - type: `null or floating point number or signed integer`
 - default: `null`
@@ -1475,7 +1493,7 @@ The scale of this output, which represents how many physical pixels fit in one l
 If this is null, niri will automatically pick a scale for you.
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.transform.flipped -->
+<!-- sorting key: programs.niri.settings.j.outputs.transform.flipped -->
 ## `programs.niri.settings.outputs.<name>.transform.flipped`
 - type: `boolean`
 - default: `false`
@@ -1483,7 +1501,7 @@ If this is null, niri will automatically pick a scale for you.
 Whether to flip this output vertically.
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.transform.rotation -->
+<!-- sorting key: programs.niri.settings.j.outputs.transform.rotation -->
 ## `programs.niri.settings.outputs.<name>.transform.rotation`
 - type: `one of 0, 90, 180, 270`
 - default: `0`
@@ -1491,7 +1509,7 @@ Whether to flip this output vertically.
 Counter-clockwise rotation of this output in degrees.
 
 
-<!-- sorting key: programs.niri.settings.i.outputs.variable-refresh-rate -->
+<!-- sorting key: programs.niri.settings.j.outputs.variable-refresh-rate -->
 ## `programs.niri.settings.outputs.<name>.variable-refresh-rate`
 - type: `one of false, "on-demand", true`
 - default: `false`
@@ -1503,10 +1521,10 @@ VRR is also known as Adaptive Sync, FreeSync, and G-Sync.
 Setting this to `"on-demand"` will enable VRR only when a window with [`window-rules.*.variable-refresh-rate`](#programsnirisettingswindow-rulesvariable-refresh-rate) is present on this output.
 
 
-<!-- sorting key: programs.niri.settings.j.cursor -->
+<!-- sorting key: programs.niri.settings.k.cursor -->
 <!-- programs.niri.settings.cursor -->
 
-<!-- sorting key: programs.niri.settings.j.cursor.hide-after-inactive-ms -->
+<!-- sorting key: programs.niri.settings.k.cursor.hide-after-inactive-ms -->
 ## `programs.niri.settings.cursor.hide-after-inactive-ms`
 - type: `null or signed integer`
 - default: `null`
@@ -1514,7 +1532,7 @@ Setting this to `"on-demand"` will enable VRR only when a window with [`window-r
 If set, the cursor will automatically hide once this number of milliseconds passes since the last cursor movement.
 
 
-<!-- sorting key: programs.niri.settings.j.cursor.hide-when-typing -->
+<!-- sorting key: programs.niri.settings.k.cursor.hide-when-typing -->
 ## `programs.niri.settings.cursor.hide-when-typing`
 - type: `boolean`
 - default: `false`
@@ -1522,7 +1540,7 @@ If set, the cursor will automatically hide once this number of milliseconds pass
 Whether to hide the cursor when typing.
 
 
-<!-- sorting key: programs.niri.settings.j.cursor.size -->
+<!-- sorting key: programs.niri.settings.k.cursor.size -->
 ## `programs.niri.settings.cursor.size`
 - type: `signed integer`
 - default: `24`
@@ -1532,7 +1550,7 @@ The size of the cursor in logical pixels.
 This will also set the XCURSOR_SIZE environment variable for all spawned processes.
 
 
-<!-- sorting key: programs.niri.settings.j.cursor.theme -->
+<!-- sorting key: programs.niri.settings.k.cursor.theme -->
 ## `programs.niri.settings.cursor.theme`
 - type: `string`
 - default: `"default"`
@@ -1542,10 +1560,10 @@ The name of the xcursor theme to use.
 This will also set the XCURSOR_THEME environment variable for all spawned processes.
 
 
-<!-- sorting key: programs.niri.settings.k.layout -->
+<!-- sorting key: programs.niri.settings.l.layout -->
 <!-- programs.niri.settings.layout -->
 
-<!-- sorting key: programs.niri.settings.k.layout.a.border -->
+<!-- sorting key: programs.niri.settings.l.layout.a.border -->
 ## `programs.niri.settings.layout.border`
 
 
@@ -1556,7 +1574,7 @@ The currently focused window, i.e. the window that can receive keyboard input, w
 If you have [`layout.focus-ring`](#programsnirisettingslayoutfocus-ring) enabled, the border will be drawn inside (and over) the focus ring.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.a.border.a.enable -->
+<!-- sorting key: programs.niri.settings.l.layout.a.border.a.enable -->
 ## `programs.niri.settings.layout.border.enable`
 - type: `boolean`
 - default: `false`
@@ -1564,7 +1582,7 @@ If you have [`layout.focus-ring`](#programsnirisettingslayoutfocus-ring) enabled
 Whether to enable the border.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.a.border.a.width -->
+<!-- sorting key: programs.niri.settings.l.layout.a.border.a.width -->
 ## `programs.niri.settings.layout.border.width`
 - type: `floating point number or signed integer`
 - default: `4`
@@ -1572,7 +1590,7 @@ Whether to enable the border.
 The width of the border drawn around each window.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.a.border.b.active -->
+<!-- sorting key: programs.niri.settings.l.layout.a.border.b.active -->
 ## `programs.niri.settings.layout.border.active`
 - type: [`<decoration>`](#decoration), which is a `variant of: color | gradient`
 - default:
@@ -1586,7 +1604,7 @@ The width of the border drawn around each window.
 The color of the border for the window that has keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.a.border.b.inactive -->
+<!-- sorting key: programs.niri.settings.l.layout.a.border.b.inactive -->
 ## `programs.niri.settings.layout.border.inactive`
 - type: [`<decoration>`](#decoration), which is a `variant of: color | gradient`
 - default:
@@ -1600,7 +1618,7 @@ The color of the border for the window that has keyboard focus.
 The color of the border for windows that do not have keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.a.focus-ring -->
+<!-- sorting key: programs.niri.settings.l.layout.a.focus-ring -->
 ## `programs.niri.settings.layout.focus-ring`
 
 
@@ -1611,7 +1629,7 @@ The focused window of the currently focused monitor, i.e. the window that can re
 If you have [`layout.border`](#programsnirisettingslayoutborder) enabled, the focus ring will be drawn around (and under) the border.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.a.focus-ring.a.enable -->
+<!-- sorting key: programs.niri.settings.l.layout.a.focus-ring.a.enable -->
 ## `programs.niri.settings.layout.focus-ring.enable`
 - type: `boolean`
 - default: `true`
@@ -1619,7 +1637,7 @@ If you have [`layout.border`](#programsnirisettingslayoutborder) enabled, the fo
 Whether to enable the focus ring.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.a.focus-ring.a.width -->
+<!-- sorting key: programs.niri.settings.l.layout.a.focus-ring.a.width -->
 ## `programs.niri.settings.layout.focus-ring.width`
 - type: `floating point number or signed integer`
 - default: `4`
@@ -1627,7 +1645,7 @@ Whether to enable the focus ring.
 The width of the focus ring drawn around each focused window.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.a.focus-ring.b.active -->
+<!-- sorting key: programs.niri.settings.l.layout.a.focus-ring.b.active -->
 ## `programs.niri.settings.layout.focus-ring.active`
 - type: [`<decoration>`](#decoration), which is a `variant of: color | gradient`
 - default:
@@ -1641,7 +1659,7 @@ The width of the focus ring drawn around each focused window.
 The color of the focus ring for the window that has keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.a.focus-ring.b.inactive -->
+<!-- sorting key: programs.niri.settings.l.layout.a.focus-ring.b.inactive -->
 ## `programs.niri.settings.layout.focus-ring.inactive`
 - type: [`<decoration>`](#decoration), which is a `variant of: color | gradient`
 - default:
@@ -1655,34 +1673,34 @@ The color of the focus ring for the window that has keyboard focus.
 The color of the focus ring for windows that do not have keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.b.shadow -->
+<!-- sorting key: programs.niri.settings.l.layout.b.shadow -->
 <!-- programs.niri.settings.layout.shadow -->
 
-<!-- sorting key: programs.niri.settings.k.layout.b.shadow.color -->
+<!-- sorting key: programs.niri.settings.l.layout.b.shadow.color -->
 ## `programs.niri.settings.layout.shadow.color`
 - type: `string`
 - default: `"#00000070"`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.b.shadow.draw-behind-window -->
+<!-- sorting key: programs.niri.settings.l.layout.b.shadow.draw-behind-window -->
 ## `programs.niri.settings.layout.shadow.draw-behind-window`
 - type: `boolean`
 - default: `false`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.b.shadow.enable -->
+<!-- sorting key: programs.niri.settings.l.layout.b.shadow.enable -->
 ## `programs.niri.settings.layout.shadow.enable`
 - type: `boolean`
 - default: `false`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.b.shadow.inactive-color -->
+<!-- sorting key: programs.niri.settings.l.layout.b.shadow.inactive-color -->
 ## `programs.niri.settings.layout.shadow.inactive-color`
 - type: `null or string`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.b.shadow.offset -->
+<!-- sorting key: programs.niri.settings.l.layout.b.shadow.offset -->
 ## `programs.niri.settings.layout.shadow.offset`
 
 
@@ -1691,19 +1709,19 @@ The offset of the shadow from the window, measured in logical pixels.
 This behaves like a [CSS box-shadow offset](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#syntax)
 
 
-<!-- sorting key: programs.niri.settings.k.layout.b.shadow.offset.x -->
+<!-- sorting key: programs.niri.settings.l.layout.b.shadow.offset.x -->
 ## `programs.niri.settings.layout.shadow.offset.x`
 - type: `floating point number or signed integer`
 - default: `0.000000`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.b.shadow.offset.y -->
+<!-- sorting key: programs.niri.settings.l.layout.b.shadow.offset.y -->
 ## `programs.niri.settings.layout.shadow.offset.y`
 - type: `floating point number or signed integer`
 - default: `5.000000`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.b.shadow.softness -->
+<!-- sorting key: programs.niri.settings.l.layout.b.shadow.softness -->
 ## `programs.niri.settings.layout.shadow.softness`
 - type: `floating point number or signed integer`
 - default: `30.000000`
@@ -1713,7 +1731,7 @@ The softness/size of the shadow, measured in logical pixels.
 This behaves like a [CSS box-shadow blur-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#syntax)
 
 
-<!-- sorting key: programs.niri.settings.k.layout.b.shadow.spread -->
+<!-- sorting key: programs.niri.settings.l.layout.b.shadow.spread -->
 ## `programs.niri.settings.layout.shadow.spread`
 - type: `floating point number or signed integer`
 - default: `5.000000`
@@ -1723,14 +1741,14 @@ The spread of the shadow, measured in logical pixels.
 This behaves like a [CSS box-shadow spread radius](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#syntax)
 
 
-<!-- sorting key: programs.niri.settings.k.layout.c.insert-hint -->
+<!-- sorting key: programs.niri.settings.l.layout.c.insert-hint -->
 ## `programs.niri.settings.layout.insert-hint`
 
 
 The insert hint is a decoration drawn *between* windows during an interactive move operation. It is drawn in the gap where the window will be inserted when you release the window. It does not occupy any space in the gap, and the insert hint extends onto the edges of adjacent windows. When you release the moved window, the windows that are covered by the insert hint will be pushed aside to make room for the moved window.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.c.insert-hint.a.enable -->
+<!-- sorting key: programs.niri.settings.l.layout.c.insert-hint.a.enable -->
 ## `programs.niri.settings.layout.insert-hint.enable`
 - type: `boolean`
 - default: `true`
@@ -1738,7 +1756,7 @@ The insert hint is a decoration drawn *between* windows during an interactive mo
 Whether to enable the insert hint.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.c.insert-hint.b.display -->
+<!-- sorting key: programs.niri.settings.l.layout.c.insert-hint.b.display -->
 ## `programs.niri.settings.layout.insert-hint.display`
 - type: [`<decoration>`](#decoration), which is a `variant of: color | gradient`
 - default:
@@ -1752,7 +1770,7 @@ Whether to enable the insert hint.
 The color of the insert hint.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.d.decoration -->
+<!-- sorting key: programs.niri.settings.l.layout.d.decoration -->
 ## `<decoration>`
 - type: `variant of: color | gradient`
 
@@ -1763,7 +1781,7 @@ This type specifically represents decorations drawn by niri: that is, [`layout.f
 
 
 
-<!-- sorting key: programs.niri.settings.k.layout.d.decoration.color -->
+<!-- sorting key: programs.niri.settings.l.layout.d.decoration.color -->
 ## `<decoration>.color`
 - type: `string`
 
@@ -1774,7 +1792,7 @@ This is a CSS [`<color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/color
 The specific crate that niri uses to parse this also supports some nonstandard color functions, like `hwba()`, `hsv()`, `hsva()`. See [`csscolorparser`](https://crates.io/crates/csscolorparser) for details.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.d.decoration.gradient -->
+<!-- sorting key: programs.niri.settings.l.layout.d.decoration.gradient -->
 ## `<decoration>.gradient`
 - type: `gradient`
 
@@ -1783,7 +1801,7 @@ A linear gradient to use for the decoration.
 This is meant to approximate the CSS [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient) function, but niri does not fully support all the same parameters. Only an angle in degrees is supported.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.d.decoration.gradient.angle -->
+<!-- sorting key: programs.niri.settings.l.layout.d.decoration.gradient.angle -->
 ## `<decoration>.gradient.angle`
 - type: `signed integer`
 - default: `180`
@@ -1793,7 +1811,7 @@ The angle of the gradient, in degrees, measured clockwise from a gradient that s
 This is the same as the angle parameter in the CSS [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/linear-gradient) function, except you can only express it in degrees.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.d.decoration.gradient.from -->
+<!-- sorting key: programs.niri.settings.l.layout.d.decoration.gradient.from -->
 ## `<decoration>.gradient.from`
 - type: `string`
 
@@ -1802,7 +1820,7 @@ The starting [`<color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_
 For more details, see [`<decoration>.color`](#decorationcolor).
 
 
-<!-- sorting key: programs.niri.settings.k.layout.d.decoration.gradient.in' -->
+<!-- sorting key: programs.niri.settings.l.layout.d.decoration.gradient.in' -->
 ## `<decoration>.gradient.in'`
 - type: `null or one of "srgb", "srgb-linear", "oklab", "oklch shorter hue", "oklch longer hue", "oklch increasing hue", "oklch decreasing hue"`
 - default: `null`
@@ -1812,7 +1830,7 @@ The colorspace to interpolate the gradient in. This option is named `in'` becaus
 This is a subset of the [`<color-interpolation-method>`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-interpolation-method) values in CSS.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.d.decoration.gradient.relative-to -->
+<!-- sorting key: programs.niri.settings.l.layout.d.decoration.gradient.relative-to -->
 ## `<decoration>.gradient.relative-to`
 - type: `one of "window", "workspace-view"`
 - default: `"window"`
@@ -1842,7 +1860,7 @@ the bottom edge of the big window is almost entirely yellow, and the top edge of
 these beautiful images are sourced from the release notes for [`v0.1.3`](https://github.com/YaLTeR/niri/releases/tag/v0.1.3)
 
 
-<!-- sorting key: programs.niri.settings.k.layout.d.decoration.gradient.to -->
+<!-- sorting key: programs.niri.settings.l.layout.d.decoration.gradient.to -->
 ## `<decoration>.gradient.to`
 - type: `string`
 
@@ -1851,7 +1869,7 @@ The ending [`<color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_va
 For more details, see [`<decoration>.color`](#decorationcolor).
 
 
-<!-- sorting key: programs.niri.settings.k.layout.e.preset-column-widths -->
+<!-- sorting key: programs.niri.settings.l.layout.e.preset-column-widths -->
 ## `programs.niri.settings.layout.preset-column-widths`
 - type: `list of variant of: fixed | proportion`
 
@@ -1874,21 +1892,21 @@ Example:
 ```
 
 
-<!-- sorting key: programs.niri.settings.k.layout.e.preset-column-widths.fixed -->
+<!-- sorting key: programs.niri.settings.l.layout.e.preset-column-widths.fixed -->
 ## `programs.niri.settings.layout.preset-column-widths.*.fixed`
 - type: `signed integer`
 
 The width of the column in logical pixels
 
 
-<!-- sorting key: programs.niri.settings.k.layout.e.preset-column-widths.proportion -->
+<!-- sorting key: programs.niri.settings.l.layout.e.preset-column-widths.proportion -->
 ## `programs.niri.settings.layout.preset-column-widths.*.proportion`
 - type: `floating point number`
 
 The width of the column as a proportion of the screen's width
 
 
-<!-- sorting key: programs.niri.settings.k.layout.e.preset-window-heights -->
+<!-- sorting key: programs.niri.settings.l.layout.e.preset-window-heights -->
 ## `programs.niri.settings.layout.preset-window-heights`
 - type: `list of variant of: fixed | proportion`
 
@@ -1911,21 +1929,21 @@ Example:
 ```
 
 
-<!-- sorting key: programs.niri.settings.k.layout.e.preset-window-heights.fixed -->
+<!-- sorting key: programs.niri.settings.l.layout.e.preset-window-heights.fixed -->
 ## `programs.niri.settings.layout.preset-window-heights.*.fixed`
 - type: `signed integer`
 
 The height of the window in logical pixels
 
 
-<!-- sorting key: programs.niri.settings.k.layout.e.preset-window-heights.proportion -->
+<!-- sorting key: programs.niri.settings.l.layout.e.preset-window-heights.proportion -->
 ## `programs.niri.settings.layout.preset-window-heights.*.proportion`
 - type: `floating point number`
 
 The height of the window as a proportion of the screen's height
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.always-center-single-column -->
+<!-- sorting key: programs.niri.settings.l.layout.f.always-center-single-column -->
 ## `programs.niri.settings.layout.always-center-single-column`
 - type: `boolean`
 - default: `false`
@@ -1933,7 +1951,7 @@ The height of the window as a proportion of the screen's height
 This is like `center-focused-column = "always";`, but only for workspaces with a single column. Changes nothing is `center-focused-column` is set to `"always"`. Has no effect if more than one column is present.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.center-focused-column -->
+<!-- sorting key: programs.niri.settings.l.layout.f.center-focused-column -->
 ## `programs.niri.settings.layout.center-focused-column`
 - type: `one of "never", "always", "on-overflow"`
 - default: `"never"`
@@ -1945,7 +1963,7 @@ When changing focus, niri can automatically center the focused column.
 - `"always"`: the focused column will always be centered, even if it was already fully visible.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.default-column-display -->
+<!-- sorting key: programs.niri.settings.l.layout.f.default-column-display -->
 ## `programs.niri.settings.layout.default-column-display`
 - type: `one of "normal", "tabbed"`
 - default: `"normal"`
@@ -1960,7 +1978,7 @@ Note that you can override this for a given column at any time. Every column rem
 Also, since a newly created column always contains a single window, you can override this default value with [`window-rules.*.default-column-display`](#programsnirisettingswindow-rulesdefault-column-display).
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.default-column-width -->
+<!-- sorting key: programs.niri.settings.l.layout.f.default-column-width -->
 ## `programs.niri.settings.layout.default-column-width`
 - type: `{} or (variant of: fixed | proportion)`
 
@@ -1973,81 +1991,81 @@ See [`layout.preset-column-widths`](#programsnirisettingslayoutpreset-column-wid
 You can override this for specific windows using [`window-rules.*.default-column-width`](#programsnirisettingswindow-rulesdefault-column-width)
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.default-column-width.fixed -->
+<!-- sorting key: programs.niri.settings.l.layout.f.default-column-width.fixed -->
 ## `programs.niri.settings.layout.default-column-width.fixed`
 - type: `signed integer`
 
 The width of the column in logical pixels
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.default-column-width.proportion -->
+<!-- sorting key: programs.niri.settings.l.layout.f.default-column-width.proportion -->
 ## `programs.niri.settings.layout.default-column-width.proportion`
 - type: `floating point number`
 
 The width of the column as a proportion of the screen's width
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator -->
 ## `programs.niri.settings.layout.tab-indicator`
 - type: `null or (submodule)`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.a.corner-radius -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.a.corner-radius -->
 ## `programs.niri.settings.layout.tab-indicator.corner-radius`
 - type: `floating point number or signed integer`
 - default: `0.000000`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.a.enable -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.a.enable -->
 ## `programs.niri.settings.layout.tab-indicator.enable`
 - type: `boolean`
 - default: `true`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.a.gap -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.a.gap -->
 ## `programs.niri.settings.layout.tab-indicator.gap`
 - type: `floating point number or signed integer`
 - default: `5.000000`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.a.gaps-between-tabs -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.a.gaps-between-tabs -->
 ## `programs.niri.settings.layout.tab-indicator.gaps-between-tabs`
 - type: `floating point number or signed integer`
 - default: `0.000000`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.a.hide-when-single-tab -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.a.hide-when-single-tab -->
 ## `programs.niri.settings.layout.tab-indicator.hide-when-single-tab`
 - type: `boolean`
 - default: `false`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.a.length.total-proportion -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.a.length.total-proportion -->
 ## `programs.niri.settings.layout.tab-indicator.length.total-proportion`
 - type: `floating point number`
 - default: `0.500000`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.a.place-within-column -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.a.place-within-column -->
 ## `programs.niri.settings.layout.tab-indicator.place-within-column`
 - type: `boolean`
 - default: `false`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.a.position -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.a.position -->
 ## `programs.niri.settings.layout.tab-indicator.position`
 - type: `one of "left", "right", "top", "bottom"`
 - default: `"left"`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.a.width -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.a.width -->
 ## `programs.niri.settings.layout.tab-indicator.width`
 - type: `floating point number or signed integer`
 - default: `4.000000`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.b.active -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.b.active -->
 ## `programs.niri.settings.layout.tab-indicator.active`
 - type: [`<decoration>`](#decoration), which is a `variant of: color | gradient`
 - default: `config.programs.niri.settings.layout.border.active`
@@ -2055,7 +2073,7 @@ The width of the column as a proportion of the screen's width
 The color of the tab indicator for the window that has keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.f.tab-indicator.b.inactive -->
+<!-- sorting key: programs.niri.settings.l.layout.f.tab-indicator.b.inactive -->
 ## `programs.niri.settings.layout.tab-indicator.inactive`
 - type: [`<decoration>`](#decoration), which is a `variant of: color | gradient`
 - default: `config.programs.niri.settings.layout.border.inactive`
@@ -2063,7 +2081,7 @@ The color of the tab indicator for the window that has keyboard focus.
 The color of the the tab indicator for windows that do not have keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.g.empty-workspace-above-first -->
+<!-- sorting key: programs.niri.settings.l.layout.g.empty-workspace-above-first -->
 ## `programs.niri.settings.layout.empty-workspace-above-first`
 - type: `boolean`
 - default: `false`
@@ -2073,7 +2091,7 @@ Normally, niri has a dynamic amount of workspaces, with one empty workspace at t
 When this is enabled, there will be an empty workspace above the first workspace, and you can go past the first workspace to get to an empty workspace, just as in the other direction. This makes workspace navigation symmetric in all ways except indexing.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.g.gaps -->
+<!-- sorting key: programs.niri.settings.l.layout.g.gaps -->
 ## `programs.niri.settings.layout.gaps`
 - type: `floating point number or signed integer`
 - default: `16`
@@ -2081,7 +2099,7 @@ When this is enabled, there will be an empty workspace above the first workspace
 The gap between windows in the layout, measured in logical pixels.
 
 
-<!-- sorting key: programs.niri.settings.k.layout.g.struts -->
+<!-- sorting key: programs.niri.settings.l.layout.g.struts -->
 ## `programs.niri.settings.layout.struts`
 
 
@@ -2094,46 +2112,46 @@ Struts are computed in addition to layer-shell surfaces. If you have a waybar of
 The left and right structs work in a similar way, except the padded space is not empty. The horizontal struts are used to constrain where focused windows are allowed to go. If you define a left strut of 64px and go to the first window in a workspace, that window will be aligned 64 logical pixels from the left edge of the output, rather than snapping to the actual edge of the screen. If another window exists to the left of this window, then you will see 64px of its right edge (if you have zero borders and gaps)
 
 
-<!-- sorting key: programs.niri.settings.k.layout.g.struts.bottom -->
+<!-- sorting key: programs.niri.settings.l.layout.g.struts.bottom -->
 ## `programs.niri.settings.layout.struts.bottom`
 - type: `floating point number or signed integer`
 - default: `0`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.g.struts.left -->
+<!-- sorting key: programs.niri.settings.l.layout.g.struts.left -->
 ## `programs.niri.settings.layout.struts.left`
 - type: `floating point number or signed integer`
 - default: `0`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.g.struts.right -->
+<!-- sorting key: programs.niri.settings.l.layout.g.struts.right -->
 ## `programs.niri.settings.layout.struts.right`
 - type: `floating point number or signed integer`
 - default: `0`
 
 
-<!-- sorting key: programs.niri.settings.k.layout.g.struts.top -->
+<!-- sorting key: programs.niri.settings.l.layout.g.struts.top -->
 ## `programs.niri.settings.layout.struts.top`
 - type: `floating point number or signed integer`
 - default: `0`
 
 
-<!-- sorting key: programs.niri.settings.l.animations -->
+<!-- sorting key: programs.niri.settings.m.animations -->
 <!-- programs.niri.settings.animations -->
 
-<!-- sorting key: programs.niri.settings.l.animations.a.enable -->
+<!-- sorting key: programs.niri.settings.m.animations.a.enable -->
 ## `programs.niri.settings.animations.enable`
 - type: `boolean`
 - default: `true`
 
 
-<!-- sorting key: programs.niri.settings.l.animations.a.slowdown -->
+<!-- sorting key: programs.niri.settings.m.animations.a.slowdown -->
 ## `programs.niri.settings.animations.slowdown`
 - type: `floating point number`
 - default: `1.000000`
 
 
-<!-- sorting key: programs.niri.settings.l.animations.b.config-notification-open-close -->
+<!-- sorting key: programs.niri.settings.m.animations.b.config-notification-open-close -->
 ## `programs.niri.settings.animations.config-notification-open-close`
 - type: `null or `[`<animation>`](#animation)
 - default:
@@ -2149,7 +2167,7 @@ The left and right structs work in a similar way, except the padded space is not
 
 
 
-<!-- sorting key: programs.niri.settings.l.animations.b.horizontal-view-movement -->
+<!-- sorting key: programs.niri.settings.m.animations.b.horizontal-view-movement -->
 ## `programs.niri.settings.animations.horizontal-view-movement`
 - type: `null or `[`<animation>`](#animation)
 - default:
@@ -2165,7 +2183,7 @@ The left and right structs work in a similar way, except the padded space is not
 
 
 
-<!-- sorting key: programs.niri.settings.l.animations.b.screenshot-ui-open -->
+<!-- sorting key: programs.niri.settings.m.animations.b.screenshot-ui-open -->
 ## `programs.niri.settings.animations.screenshot-ui-open`
 - type: `null or `[`<animation>`](#animation)
 - default:
@@ -2180,7 +2198,7 @@ The left and right structs work in a similar way, except the padded space is not
 
 
 
-<!-- sorting key: programs.niri.settings.l.animations.b.window-close -->
+<!-- sorting key: programs.niri.settings.m.animations.b.window-close -->
 ## `programs.niri.settings.animations.window-close`
 - type: `null or `[`<animation>`](#animation)
 - default:
@@ -2195,7 +2213,7 @@ The left and right structs work in a similar way, except the padded space is not
 
 
 
-<!-- sorting key: programs.niri.settings.l.animations.b.window-movement -->
+<!-- sorting key: programs.niri.settings.m.animations.b.window-movement -->
 ## `programs.niri.settings.animations.window-movement`
 - type: `null or `[`<animation>`](#animation)
 - default:
@@ -2211,7 +2229,7 @@ The left and right structs work in a similar way, except the padded space is not
 
 
 
-<!-- sorting key: programs.niri.settings.l.animations.b.window-open -->
+<!-- sorting key: programs.niri.settings.m.animations.b.window-open -->
 ## `programs.niri.settings.animations.window-open`
 - type: `null or `[`<animation>`](#animation)
 - default:
@@ -2226,7 +2244,7 @@ The left and right structs work in a similar way, except the padded space is not
 
 
 
-<!-- sorting key: programs.niri.settings.l.animations.b.window-resize -->
+<!-- sorting key: programs.niri.settings.m.animations.b.window-resize -->
 ## `programs.niri.settings.animations.window-resize`
 - type: `null or `[`<animation>`](#animation)
 - default:
@@ -2242,7 +2260,7 @@ The left and right structs work in a similar way, except the padded space is not
 
 
 
-<!-- sorting key: programs.niri.settings.l.animations.b.workspace-switch -->
+<!-- sorting key: programs.niri.settings.m.animations.b.workspace-switch -->
 ## `programs.niri.settings.animations.workspace-switch`
 - type: `null or `[`<animation>`](#animation)
 - default:
@@ -2258,7 +2276,7 @@ The left and right structs work in a similar way, except the padded space is not
 
 
 
-<!-- sorting key: programs.niri.settings.l.animations.c.shaders -->
+<!-- sorting key: programs.niri.settings.m.animations.c.shaders -->
 ## `programs.niri.settings.animations.shaders`
 
 
@@ -2267,69 +2285,69 @@ These options should contain the *source code* for GLSL shaders.
 See: https://github.com/YaLTeR/niri/wiki/Configuration:-Animations#custom-shader
 
 
-<!-- sorting key: programs.niri.settings.l.animations.c.shaders.window-close -->
+<!-- sorting key: programs.niri.settings.m.animations.c.shaders.window-close -->
 ## `programs.niri.settings.animations.shaders.window-close`
 - type: `null or string`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.l.animations.c.shaders.window-open -->
+<!-- sorting key: programs.niri.settings.m.animations.c.shaders.window-open -->
 ## `programs.niri.settings.animations.shaders.window-open`
 - type: `null or string`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.l.animations.c.shaders.window-resize -->
+<!-- sorting key: programs.niri.settings.m.animations.c.shaders.window-resize -->
 ## `programs.niri.settings.animations.shaders.window-resize`
 - type: `null or string`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.l.animations.d.<animation> -->
+<!-- sorting key: programs.niri.settings.m.animations.d.<animation> -->
 ## `<animation>`
 - type: `variant of: easing | spring`
 
 
-<!-- sorting key: programs.niri.settings.l.animations.d.<animation>.easing -->
+<!-- sorting key: programs.niri.settings.m.animations.d.<animation>.easing -->
 <!-- <animation>.easing -->
 
-<!-- sorting key: programs.niri.settings.l.animations.d.<animation>.easing.curve -->
+<!-- sorting key: programs.niri.settings.m.animations.d.<animation>.easing.curve -->
 ## `<animation>.easing.curve`
 - type: `one of "linear", "ease-out-quad", "ease-out-cubic", "ease-out-expo"`
 
 The curve to use for the easing function.
 
 
-<!-- sorting key: programs.niri.settings.l.animations.d.<animation>.easing.duration-ms -->
+<!-- sorting key: programs.niri.settings.m.animations.d.<animation>.easing.duration-ms -->
 ## `<animation>.easing.duration-ms`
 - type: `signed integer`
 
 
-<!-- sorting key: programs.niri.settings.l.animations.d.<animation>.spring -->
+<!-- sorting key: programs.niri.settings.m.animations.d.<animation>.spring -->
 <!-- <animation>.spring -->
 
-<!-- sorting key: programs.niri.settings.l.animations.d.<animation>.spring.damping-ratio -->
+<!-- sorting key: programs.niri.settings.m.animations.d.<animation>.spring.damping-ratio -->
 ## `<animation>.spring.damping-ratio`
 - type: `floating point number`
 
 
-<!-- sorting key: programs.niri.settings.l.animations.d.<animation>.spring.epsilon -->
+<!-- sorting key: programs.niri.settings.m.animations.d.<animation>.spring.epsilon -->
 ## `<animation>.spring.epsilon`
 - type: `floating point number`
 
 
-<!-- sorting key: programs.niri.settings.l.animations.d.<animation>.spring.stiffness -->
+<!-- sorting key: programs.niri.settings.m.animations.d.<animation>.spring.stiffness -->
 ## `<animation>.spring.stiffness`
 - type: `signed integer`
 
 
-<!-- sorting key: programs.niri.settings.l.gestures -->
+<!-- sorting key: programs.niri.settings.m.gestures -->
 ## `programs.niri.settings.gestures`
 - type: `null or (submodule)`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.l.gestures.dnd-edge-view-scroll.delay-ms -->
+<!-- sorting key: programs.niri.settings.m.gestures.dnd-edge-view-scroll.delay-ms -->
 ## `programs.niri.settings.gestures.dnd-edge-view-scroll.delay-ms`
 - type: `signed integer`
 - default: `100`
@@ -2337,7 +2355,7 @@ The curve to use for the easing function.
 The delay in milliseconds before the view starts scrolling.
 
 
-<!-- sorting key: programs.niri.settings.l.gestures.dnd-edge-view-scroll.max-speed -->
+<!-- sorting key: programs.niri.settings.m.gestures.dnd-edge-view-scroll.max-speed -->
 ## `programs.niri.settings.gestures.dnd-edge-view-scroll.max-speed`
 - type: `floating point number or signed integer`
 - default: `1500.000000`
@@ -2345,7 +2363,7 @@ The delay in milliseconds before the view starts scrolling.
 When the cursor is at boundary of the trigger width, the view will not be scrolling. Moving the mouse further away from the boundary and closer to the egde will linearly increase the scrolling speed, until the mouse is pressed against the edge of the screen, at which point the view will scroll at this speed. The speed is measured in logical pixels per second.
 
 
-<!-- sorting key: programs.niri.settings.l.gestures.dnd-edge-view-scroll.trigger-width -->
+<!-- sorting key: programs.niri.settings.m.gestures.dnd-edge-view-scroll.trigger-width -->
 ## `programs.niri.settings.gestures.dnd-edge-view-scroll.trigger-width`
 - type: `floating point number or signed integer`
 - default: `30.000000`
@@ -2353,7 +2371,7 @@ When the cursor is at boundary of the trigger width, the view will not be scroll
 The width of the edge of the screen where dragging a window will scroll the view.
 
 
-<!-- sorting key: programs.niri.settings.l.gestures.hot-corners.enable -->
+<!-- sorting key: programs.niri.settings.m.gestures.hot-corners.enable -->
 ## `programs.niri.settings.gestures.hot-corners.enable`
 - type: `null or boolean`
 - default: `null`
@@ -2361,7 +2379,7 @@ The width of the edge of the screen where dragging a window will scroll the view
 Put your mouse at the very top-left corner of a monitor to toggle the overview. Also works during drag-and-dropping something.
 
 
-<!-- sorting key: programs.niri.settings.m.environment -->
+<!-- sorting key: programs.niri.settings.n.environment -->
 ## `programs.niri.settings.environment`
 - type: `attribute set of (null or string)`
 
@@ -2383,7 +2401,7 @@ Examples:
 ```
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules -->
+<!-- sorting key: programs.niri.settings.o.window-rules -->
 ## `programs.niri.settings.window-rules`
 - type: `list of window rule`
 
@@ -2428,7 +2446,7 @@ The "final value" of a field is simply its value at the end of this process. Tha
 If the final value of a given field is null, then it usually means that the client gets to decide. For more information, see the documentation for each field.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.a.matches -->
+<!-- sorting key: programs.niri.settings.o.window-rules.a.matches -->
 ## `programs.niri.settings.window-rules.*.matches`
 - type: `list of match rule`
 
@@ -2439,7 +2457,7 @@ If any of these rules match a window (or there are none), that window rule will 
 If all of the rules do not match a window, then this window rule will not apply to that window.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.a.matches.a.app-id -->
+<!-- sorting key: programs.niri.settings.o.window-rules.a.matches.a.app-id -->
 ## `programs.niri.settings.window-rules.*.matches.*.app-id`
 - type: `null or regular expression`
 - default: `null`
@@ -2449,7 +2467,7 @@ A regular expression to match against the app id of the window.
 When non-null, for this field to match a window, a client must set the app id of its window and the app id must match this regex.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.a.matches.a.title -->
+<!-- sorting key: programs.niri.settings.o.window-rules.a.matches.a.title -->
 ## `programs.niri.settings.window-rules.*.matches.*.title`
 - type: `null or regular expression`
 - default: `null`
@@ -2459,7 +2477,7 @@ A regular expression to match against the title of the window.
 When non-null, for this field to match a window, a client must set the title of its window and the title must match this regex.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.a.matches.b.is-active -->
+<!-- sorting key: programs.niri.settings.o.window-rules.a.matches.b.is-active -->
 ## `programs.niri.settings.window-rules.*.matches.*.is-active`
 - type: `null or boolean`
 - default: `null`
@@ -2469,7 +2487,7 @@ When non-null, for this field to match a window, the value must match whether th
 Every monitor has up to one active window, and `is-active=true` will match the active window on each monitor. A monitor can have zero active windows if no windows are open on it. There can never be more than one active window on a monitor.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.a.matches.b.is-active-in-column -->
+<!-- sorting key: programs.niri.settings.o.window-rules.a.matches.b.is-active-in-column -->
 ## `programs.niri.settings.window-rules.*.matches.*.is-active-in-column`
 - type: `null or boolean`
 - default: `null`
@@ -2481,7 +2499,7 @@ Every column has exactly one active-in-column window. If it is the active column
 The active-in-column window is the window that was last focused in that column. When you switch focus to a column, the active-in-column window will be the new focused window.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.a.matches.b.is-floating -->
+<!-- sorting key: programs.niri.settings.o.window-rules.a.matches.b.is-floating -->
 ## `programs.niri.settings.window-rules.*.matches.*.is-floating`
 - type: `null or boolean`
 - default: `null`
@@ -2489,7 +2507,7 @@ The active-in-column window is the window that was last focused in that column. 
 When not-null, for this field to match a window, the value must match whether the window is floating (true) or tiled (false).
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.a.matches.b.is-focused -->
+<!-- sorting key: programs.niri.settings.o.window-rules.a.matches.b.is-focused -->
 ## `programs.niri.settings.window-rules.*.matches.*.is-focused`
 - type: `null or boolean`
 - default: `null`
@@ -2501,7 +2519,7 @@ A note on terminology used here: a window is actually a toplevel surface, and a 
 For a window to be focused, its surface must be focused. There is up to one focused surface, and it is the surface that can receive keyboard input. There can never be more than one focused surface. There can be zero focused surfaces if and only if there are zero surfaces. The focused surface does *not* have to be a toplevel surface. It can also be a layer-shell surface. In that case, there is a surface with keyboard focus but no *window* with keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.a.matches.b.is-window-cast-target -->
+<!-- sorting key: programs.niri.settings.o.window-rules.a.matches.b.is-window-cast-target -->
 ## `programs.niri.settings.window-rules.*.matches.*.is-window-cast-target`
 - type: `null or boolean`
 - default: `null`
@@ -2509,7 +2527,7 @@ For a window to be focused, its surface must be focused. There is up to one focu
 When non-null, matches based on whether the window is being targeted by a window cast.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.a.matches.c.at-startup -->
+<!-- sorting key: programs.niri.settings.o.window-rules.a.matches.c.at-startup -->
 ## `programs.niri.settings.window-rules.*.matches.*.at-startup`
 - type: `null or boolean`
 - default: `null`
@@ -2517,7 +2535,7 @@ When non-null, matches based on whether the window is being targeted by a window
 When true, this rule will match windows opened within the first 60 seconds of niri starting up. When false, this rule will match windows opened *more than* 60 seconds after niri started up. This is useful for applying different rules to windows opened from [`spawn-at-startup`](#programsnirisettingsspawn-at-startup) versus those opened later.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.b.excludes -->
+<!-- sorting key: programs.niri.settings.o.window-rules.b.excludes -->
 ## `programs.niri.settings.window-rules.*.excludes`
 - type: `list of match rule`
 
@@ -2528,7 +2546,7 @@ If any of these rules match a window, then this window rule will not apply to th
 If none of these rules match a window, then this window rule will not be rejected. It will apply to that window if and only if it matches one of the rules in [`window-rules.*.matches`](#programsnirisettingswindow-rulesmatches)
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.b.excludes.a.app-id -->
+<!-- sorting key: programs.niri.settings.o.window-rules.b.excludes.a.app-id -->
 ## `programs.niri.settings.window-rules.*.excludes.*.app-id`
 - type: `null or regular expression`
 - default: `null`
@@ -2538,7 +2556,7 @@ A regular expression to match against the app id of the window.
 When non-null, for this field to match a window, a client must set the app id of its window and the app id must match this regex.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.b.excludes.a.title -->
+<!-- sorting key: programs.niri.settings.o.window-rules.b.excludes.a.title -->
 ## `programs.niri.settings.window-rules.*.excludes.*.title`
 - type: `null or regular expression`
 - default: `null`
@@ -2548,7 +2566,7 @@ A regular expression to match against the title of the window.
 When non-null, for this field to match a window, a client must set the title of its window and the title must match this regex.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.b.excludes.b.is-active -->
+<!-- sorting key: programs.niri.settings.o.window-rules.b.excludes.b.is-active -->
 ## `programs.niri.settings.window-rules.*.excludes.*.is-active`
 - type: `null or boolean`
 - default: `null`
@@ -2558,7 +2576,7 @@ When non-null, for this field to match a window, the value must match whether th
 Every monitor has up to one active window, and `is-active=true` will match the active window on each monitor. A monitor can have zero active windows if no windows are open on it. There can never be more than one active window on a monitor.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.b.excludes.b.is-active-in-column -->
+<!-- sorting key: programs.niri.settings.o.window-rules.b.excludes.b.is-active-in-column -->
 ## `programs.niri.settings.window-rules.*.excludes.*.is-active-in-column`
 - type: `null or boolean`
 - default: `null`
@@ -2570,7 +2588,7 @@ Every column has exactly one active-in-column window. If it is the active column
 The active-in-column window is the window that was last focused in that column. When you switch focus to a column, the active-in-column window will be the new focused window.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.b.excludes.b.is-floating -->
+<!-- sorting key: programs.niri.settings.o.window-rules.b.excludes.b.is-floating -->
 ## `programs.niri.settings.window-rules.*.excludes.*.is-floating`
 - type: `null or boolean`
 - default: `null`
@@ -2578,7 +2596,7 @@ The active-in-column window is the window that was last focused in that column. 
 When not-null, for this field to match a window, the value must match whether the window is floating (true) or tiled (false).
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.b.excludes.b.is-focused -->
+<!-- sorting key: programs.niri.settings.o.window-rules.b.excludes.b.is-focused -->
 ## `programs.niri.settings.window-rules.*.excludes.*.is-focused`
 - type: `null or boolean`
 - default: `null`
@@ -2590,7 +2608,7 @@ A note on terminology used here: a window is actually a toplevel surface, and a 
 For a window to be focused, its surface must be focused. There is up to one focused surface, and it is the surface that can receive keyboard input. There can never be more than one focused surface. There can be zero focused surfaces if and only if there are zero surfaces. The focused surface does *not* have to be a toplevel surface. It can also be a layer-shell surface. In that case, there is a surface with keyboard focus but no *window* with keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.b.excludes.b.is-window-cast-target -->
+<!-- sorting key: programs.niri.settings.o.window-rules.b.excludes.b.is-window-cast-target -->
 ## `programs.niri.settings.window-rules.*.excludes.*.is-window-cast-target`
 - type: `null or boolean`
 - default: `null`
@@ -2598,7 +2616,7 @@ For a window to be focused, its surface must be focused. There is up to one focu
 When non-null, matches based on whether the window is being targeted by a window cast.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.b.excludes.c.at-startup -->
+<!-- sorting key: programs.niri.settings.o.window-rules.b.excludes.c.at-startup -->
 ## `programs.niri.settings.window-rules.*.excludes.*.at-startup`
 - type: `null or boolean`
 - default: `null`
@@ -2606,7 +2624,7 @@ When non-null, matches based on whether the window is being targeted by a window
 When true, this rule will match windows opened within the first 60 seconds of niri starting up. When false, this rule will match windows opened *more than* 60 seconds after niri started up. This is useful for applying different rules to windows opened from [`spawn-at-startup`](#programsnirisettingsspawn-at-startup) versus those opened later.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.c.default-column-display -->
+<!-- sorting key: programs.niri.settings.o.window-rules.c.default-column-display -->
 ## `programs.niri.settings.window-rules.*.default-column-display`
 - type: `null or one of "normal", "tabbed"`
 - default: `null`
@@ -2616,7 +2634,7 @@ When this window is inserted into the tiling layout such that a new column is cr
 If the final value of this field is null, then the default display mode is taken from [`layout.default-column-display`](#programsnirisettingslayoutdefault-column-display).
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.c.default-column-width -->
+<!-- sorting key: programs.niri.settings.o.window-rules.c.default-column-width -->
 ## `programs.niri.settings.window-rules.*.default-column-width`
 - type: `null or {} or (variant of: fixed | proportion)`
 - default: `null`
@@ -2631,21 +2649,21 @@ An empty attrset `{}` is not the same as null. When this is set to an empty attr
 
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.c.default-column-width.fixed -->
+<!-- sorting key: programs.niri.settings.o.window-rules.c.default-column-width.fixed -->
 ## `programs.niri.settings.window-rules.*.default-column-width.fixed`
 - type: `signed integer`
 
 The width of the column in logical pixels
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.c.default-column-width.proportion -->
+<!-- sorting key: programs.niri.settings.o.window-rules.c.default-column-width.proportion -->
 ## `programs.niri.settings.window-rules.*.default-column-width.proportion`
 - type: `floating point number`
 
 The width of the column as a proportion of the screen's width
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.c.default-window-height -->
+<!-- sorting key: programs.niri.settings.o.window-rules.c.default-window-height -->
 ## `programs.niri.settings.window-rules.*.default-window-height`
 - type: `null or {} or (variant of: fixed | proportion)`
 - default: `null`
@@ -2663,21 +2681,21 @@ If the final value of this option is an empty attrset `{}`, then the client gets
 If the final value of this option is not an empty attrset `{}`, and the window spawns as floating, then the window will be created with the specified height.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.c.default-window-height.fixed -->
+<!-- sorting key: programs.niri.settings.o.window-rules.c.default-window-height.fixed -->
 ## `programs.niri.settings.window-rules.*.default-window-height.fixed`
 - type: `signed integer`
 
 The height of the window in logical pixels
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.c.default-window-height.proportion -->
+<!-- sorting key: programs.niri.settings.o.window-rules.c.default-window-height.proportion -->
 ## `programs.niri.settings.window-rules.*.default-window-height.proportion`
 - type: `floating point number`
 
 The height of the window as a proportion of the screen's height
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.d.open-floating -->
+<!-- sorting key: programs.niri.settings.o.window-rules.d.open-floating -->
 ## `programs.niri.settings.window-rules.*.open-floating`
 - type: `null or boolean`
 - default: `null`
@@ -2691,7 +2709,7 @@ If the final value of this field is false, then this window is never allowed to 
 If the final value of this field is null, then niri will decide whether to open the window as floating or as tiled.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.d.open-focused -->
+<!-- sorting key: programs.niri.settings.o.window-rules.d.open-focused -->
 ## `programs.niri.settings.window-rules.*.open-focused`
 - type: `null or boolean`
 - default: `null`
@@ -2710,7 +2728,7 @@ If the final value of this field is null, then the window will be focused based 
 If the final value of this field is not null, all of the above is ignored. Whether the window provides an activation token or not, doesn't matter. The window will be focused if and only if this field is true. If it is false, the window will not be focused, even if it provides a valid activation token.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.d.open-fullscreen -->
+<!-- sorting key: programs.niri.settings.o.window-rules.d.open-fullscreen -->
 ## `programs.niri.settings.window-rules.*.open-fullscreen`
 - type: `null or boolean`
 - default: `null`
@@ -2724,7 +2742,7 @@ If the final value of this field is false, then this window is never allowed to 
 If the final value of this field is null, then the client gets to decide if this window will open in fullscreen.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.d.open-maximized -->
+<!-- sorting key: programs.niri.settings.o.window-rules.d.open-maximized -->
 ## `programs.niri.settings.window-rules.*.open-maximized`
 - type: `null or boolean`
 - default: `null`
@@ -2736,7 +2754,7 @@ If the final value of this field is null or false, then the window will not open
 If the final value of this field is true, then the window will open in a maximized column.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.d.open-on-output -->
+<!-- sorting key: programs.niri.settings.o.window-rules.d.open-on-output -->
 ## `programs.niri.settings.window-rules.*.open-on-output`
 - type: `null or string`
 - default: `null`
@@ -2748,7 +2766,7 @@ If final value of this field is an output that exists, the new window will open 
 If the final value is an output that does not exist, or it is null, then the window opens on the currently focused output.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.d.open-on-workspace -->
+<!-- sorting key: programs.niri.settings.o.window-rules.d.open-on-workspace -->
 ## `programs.niri.settings.window-rules.*.open-on-workspace`
 - type: `null or string`
 - default: `null`
@@ -2760,7 +2778,7 @@ If the final value of this field is a named workspace that exists, the window wi
 If the final value of this is a named workspace that does not exist, or it is null, the window opens on the currently focused workspace.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.block-out-from -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.block-out-from -->
 ## `programs.niri.settings.window-rules.*.block-out-from`
 - type: `null or one of "screencast", "screen-capture"`
 - default: `null`
@@ -2811,14 +2829,14 @@ There are three methods of screencapture in niri:
 Essentially, use `block-out-from = "screen-capture";` if you want to be sure that the window is never visible to any external tool no matter what; or use `block-out-from = "screencast";` if you want to be able to capture screenshots of the window without its contents normally being visible in a screencast. (at the risk of some tools still leaking the window contents, see above)
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.border -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.border -->
 ## `programs.niri.settings.window-rules.*.border`
 
 
 See [`layout.border`](#programsnirisettingslayoutborder).
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.border.a.enable -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.border.a.enable -->
 ## `programs.niri.settings.window-rules.*.border.enable`
 - type: `null or boolean`
 - default: `null`
@@ -2826,7 +2844,7 @@ See [`layout.border`](#programsnirisettingslayoutborder).
 Whether to enable the border.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.border.a.width -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.border.a.width -->
 ## `programs.niri.settings.window-rules.*.border.width`
 - type: `null or floating point number or signed integer`
 - default: `null`
@@ -2834,7 +2852,7 @@ Whether to enable the border.
 The width of the border drawn around each matched window.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.border.b.active -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.border.b.active -->
 ## `programs.niri.settings.window-rules.*.border.active`
 - type: `null or `[`<decoration>`](#decoration)
 - default: `null`
@@ -2842,7 +2860,7 @@ The width of the border drawn around each matched window.
 The color of the border for the window that has keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.border.b.inactive -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.border.b.inactive -->
 ## `programs.niri.settings.window-rules.*.border.inactive`
 - type: `null or `[`<decoration>`](#decoration)
 - default: `null`
@@ -2850,7 +2868,7 @@ The color of the border for the window that has keyboard focus.
 The color of the border for windows that do not have keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.clip-to-geometry -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.clip-to-geometry -->
 ## `programs.niri.settings.window-rules.*.clip-to-geometry`
 - type: `null or boolean`
 - default: `null`
@@ -2858,7 +2876,7 @@ The color of the border for windows that do not have keyboard focus.
 Whether to clip the window to its visual geometry, i.e. whether the corner radius should be applied to the window surface itself or just the decorations.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.draw-border-with-background -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.draw-border-with-background -->
 ## `programs.niri.settings.window-rules.*.draw-border-with-background`
 - type: `null or boolean`
 - default: `null`
@@ -2876,14 +2894,14 @@ If you wish to make windows sucha s your terminal transparent, and they use CSD,
 You can set this option per window to override niri's default behaviour, and instruct it to omit the border background for CSD windows. You can also explicitly enable it for SSD windows.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.focus-ring -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.focus-ring -->
 ## `programs.niri.settings.window-rules.*.focus-ring`
 
 
 See [`layout.focus-ring`](#programsnirisettingslayoutfocus-ring).
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.focus-ring.a.enable -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.focus-ring.a.enable -->
 ## `programs.niri.settings.window-rules.*.focus-ring.enable`
 - type: `null or boolean`
 - default: `null`
@@ -2891,7 +2909,7 @@ See [`layout.focus-ring`](#programsnirisettingslayoutfocus-ring).
 Whether to enable the focus ring.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.focus-ring.a.width -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.focus-ring.a.width -->
 ## `programs.niri.settings.window-rules.*.focus-ring.width`
 - type: `null or floating point number or signed integer`
 - default: `null`
@@ -2899,7 +2917,7 @@ Whether to enable the focus ring.
 The width of the focus ring drawn around each matched window with focus.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.focus-ring.b.active -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.focus-ring.b.active -->
 ## `programs.niri.settings.window-rules.*.focus-ring.active`
 - type: `null or `[`<decoration>`](#decoration)
 - default: `null`
@@ -2907,7 +2925,7 @@ The width of the focus ring drawn around each matched window with focus.
 The color of the focus ring for the window that has keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.focus-ring.b.inactive -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.focus-ring.b.inactive -->
 ## `programs.niri.settings.window-rules.*.focus-ring.inactive`
 - type: `null or `[`<decoration>`](#decoration)
 - default: `null`
@@ -2915,7 +2933,7 @@ The color of the focus ring for the window that has keyboard focus.
 The color of the focus ring for windows that do not have keyboard focus.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.geometry-corner-radius -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.geometry-corner-radius -->
 ## `programs.niri.settings.window-rules.*.geometry-corner-radius`
 - type: `null or (submodule)`
 - default: `null`
@@ -2927,27 +2945,27 @@ By default, the actual window surface will be unaffected by this.
 Set [`window-rules.*.clip-to-geometry`](#programsnirisettingswindow-rulesclip-to-geometry) to true to clip the window to its visual geometry, i.e. apply the corner radius to the window surface itself.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.geometry-corner-radius.bottom-left -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.geometry-corner-radius.bottom-left -->
 ## `programs.niri.settings.window-rules.*.geometry-corner-radius.bottom-left`
 - type: `floating point number`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.geometry-corner-radius.bottom-right -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.geometry-corner-radius.bottom-right -->
 ## `programs.niri.settings.window-rules.*.geometry-corner-radius.bottom-right`
 - type: `floating point number`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.geometry-corner-radius.top-left -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.geometry-corner-radius.top-left -->
 ## `programs.niri.settings.window-rules.*.geometry-corner-radius.top-left`
 - type: `floating point number`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.geometry-corner-radius.top-right -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.geometry-corner-radius.top-right -->
 ## `programs.niri.settings.window-rules.*.geometry-corner-radius.top-right`
 - type: `floating point number`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.opacity -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.opacity -->
 ## `programs.niri.settings.window-rules.*.opacity`
 - type: `null or floating point number`
 - default: `null`
@@ -2959,34 +2977,34 @@ If the final value of this field is null, niri will fall back to a value of 1.
 Note that this is applied in addition to the opacity set by the client. Setting this to a semitransparent value on a window that is already semitransparent will make it even more transparent.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.shadow -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.shadow -->
 <!-- programs.niri.settings.window-rules.*.shadow -->
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.shadow.color -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.shadow.color -->
 ## `programs.niri.settings.window-rules.*.shadow.color`
 - type: `null or string`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.shadow.draw-behind-window -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.shadow.draw-behind-window -->
 ## `programs.niri.settings.window-rules.*.shadow.draw-behind-window`
 - type: `null or boolean`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.shadow.enable -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.shadow.enable -->
 ## `programs.niri.settings.window-rules.*.shadow.enable`
 - type: `null or boolean`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.shadow.inactive-color -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.shadow.inactive-color -->
 ## `programs.niri.settings.window-rules.*.shadow.inactive-color`
 - type: `null or string`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.shadow.offset -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.shadow.offset -->
 ## `programs.niri.settings.window-rules.*.shadow.offset`
 - type: `null or (submodule)`
 - default: `null`
@@ -2996,17 +3014,17 @@ The offset of the shadow from the window, measured in logical pixels.
 This behaves like a [CSS box-shadow offset](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#syntax)
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.shadow.offset.x -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.shadow.offset.x -->
 ## `programs.niri.settings.window-rules.*.shadow.offset.x`
 - type: `floating point number or signed integer`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.shadow.offset.y -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.shadow.offset.y -->
 ## `programs.niri.settings.window-rules.*.shadow.offset.y`
 - type: `floating point number or signed integer`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.shadow.softness -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.shadow.softness -->
 ## `programs.niri.settings.window-rules.*.shadow.softness`
 - type: `null or floating point number or signed integer`
 - default: `null`
@@ -3016,7 +3034,7 @@ The softness/size of the shadow, measured in logical pixels.
 This behaves like a [CSS box-shadow blur-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#syntax)
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.shadow.spread -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.shadow.spread -->
 ## `programs.niri.settings.window-rules.*.shadow.spread`
 - type: `null or floating point number or signed integer`
 - default: `null`
@@ -3026,7 +3044,7 @@ The spread of the shadow, measured in logical pixels.
 This behaves like a [CSS box-shadow spread radius](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#syntax)
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.tab-indicator.active -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.tab-indicator.active -->
 ## `programs.niri.settings.window-rules.*.tab-indicator.active`
 - type: `null or `[`<decoration>`](#decoration)
 - default: `null`
@@ -3034,7 +3052,7 @@ This behaves like a [CSS box-shadow spread radius](https://developer.mozilla.org
 See [`layout.tab-indicator.active`](#programsnirisettingslayouttab-indicatoractive).
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.e.tab-indicator.inactive -->
+<!-- sorting key: programs.niri.settings.o.window-rules.e.tab-indicator.inactive -->
 ## `programs.niri.settings.window-rules.*.tab-indicator.inactive`
 - type: `null or `[`<decoration>`](#decoration)
 - default: `null`
@@ -3042,7 +3060,7 @@ See [`layout.tab-indicator.active`](#programsnirisettingslayouttab-indicatoracti
 See [`layout.tab-indicator.inactive`](#programsnirisettingslayouttab-indicatorinactive).
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.f.max-height -->
+<!-- sorting key: programs.niri.settings.o.window-rules.f.max-height -->
 ## `programs.niri.settings.window-rules.*.max-height`
 - type: `null or signed integer`
 - default: `null`
@@ -3057,7 +3075,7 @@ Also, note that the maximum height is not taken into account when automatically 
 If you manually change the window heights, then max-height will be taken into account and restrict you from making it any taller, as you'd intuitively expect.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.f.max-width -->
+<!-- sorting key: programs.niri.settings.o.window-rules.f.max-width -->
 ## `programs.niri.settings.window-rules.*.max-width`
 - type: `null or signed integer`
 - default: `null`
@@ -3067,7 +3085,7 @@ Sets the maximum width (in logical pixels) that niri will ever ask this window f
 Keep in mind that the window itself always has a final say in its size, and may not respect the maximum width set by this option.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.f.min-height -->
+<!-- sorting key: programs.niri.settings.o.window-rules.f.min-height -->
 ## `programs.niri.settings.window-rules.*.min-height`
 - type: `null or signed integer`
 - default: `null`
@@ -3077,7 +3095,7 @@ Sets the minimum height (in logical pixels) that niri will ever ask this window 
 Keep in mind that the window itself always has a final say in its size, and may not respect the minimum height set by this option.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.f.min-width -->
+<!-- sorting key: programs.niri.settings.o.window-rules.f.min-width -->
 ## `programs.niri.settings.window-rules.*.min-width`
 - type: `null or signed integer`
 - default: `null`
@@ -3087,7 +3105,7 @@ Sets the minimum width (in logical pixels) that niri will ever ask this window f
 Keep in mind that the window itself always has a final say in its size, and may not respect the minimum width set by this option.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.g.baba-is-float -->
+<!-- sorting key: programs.niri.settings.o.window-rules.g.baba-is-float -->
 ## `programs.niri.settings.window-rules.*.baba-is-float`
 - type: `null or boolean`
 - default: `null`
@@ -3097,7 +3115,7 @@ Makes your window FLOAT up and down, like in the game Baba Is You.
 Made for April Fools 2025.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.g.default-floating-position -->
+<!-- sorting key: programs.niri.settings.o.window-rules.g.default-floating-position -->
 ## `programs.niri.settings.window-rules.*.default-floating-position`
 - type: `null or (submodule)`
 - default: `null`
@@ -3113,22 +3131,22 @@ If a window has already been placed as floating through one of the above methods
 The `x` and `y` fields are the distances from the edge of the screen to the edge of the window, in logical pixels. The `relative-to` field determines which two edges of the window and screen that these distances are measured from.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.g.default-floating-position.relative-to -->
+<!-- sorting key: programs.niri.settings.o.window-rules.g.default-floating-position.relative-to -->
 ## `programs.niri.settings.window-rules.*.default-floating-position.relative-to`
 - type: `one of "top-left", "top-right", "bottom-left", "bottom-right"`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.g.default-floating-position.x -->
+<!-- sorting key: programs.niri.settings.o.window-rules.g.default-floating-position.x -->
 ## `programs.niri.settings.window-rules.*.default-floating-position.x`
 - type: `floating point number or signed integer`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.g.default-floating-position.y -->
+<!-- sorting key: programs.niri.settings.o.window-rules.g.default-floating-position.y -->
 ## `programs.niri.settings.window-rules.*.default-floating-position.y`
 - type: `floating point number or signed integer`
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.h.variable-refresh-rate -->
+<!-- sorting key: programs.niri.settings.o.window-rules.h.variable-refresh-rate -->
 ## `programs.niri.settings.window-rules.*.variable-refresh-rate`
 - type: `null or boolean`
 - default: `null`
@@ -3136,13 +3154,13 @@ The `x` and `y` fields are the distances from the edge of the screen to the edge
 Takes effect only when the window is on an output with [`outputs.*.variable-refresh-rate`](#programsnirisettingsoutputsvariable-refresh-rate) set to `"on-demand"`. If the final value of this field is true, then the output will enable variable refresh rate when this window is present on it.
 
 
-<!-- sorting key: programs.niri.settings.n.window-rules.i.scroll-factor -->
+<!-- sorting key: programs.niri.settings.o.window-rules.i.scroll-factor -->
 ## `programs.niri.settings.window-rules.*.scroll-factor`
 - type: `null or floating point number or signed integer`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules -->
+<!-- sorting key: programs.niri.settings.p.layer-rules -->
 ## `programs.niri.settings.layer-rules`
 - type: `list of layer rule`
 
@@ -3185,7 +3203,7 @@ The "final value" of a field is simply its value at the end of this process. Tha
 If the final value of a given field is null, then it usually means that the client gets to decide. For more information, see the documentation for each field.
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.a.matches -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.a.matches -->
 ## `programs.niri.settings.layer-rules.*.matches`
 - type: `list of match rule`
 
@@ -3196,7 +3214,7 @@ If any of these rules match a layer surface (or there are none), that layer rule
 If all of the rules do not match a layer surface, then this layer rule will not apply to that layer surface.
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.a.matches.a.namespace -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.a.matches.a.namespace -->
 ## `programs.niri.settings.layer-rules.*.matches.*.namespace`
 - type: `null or regular expression`
 - default: `null`
@@ -3206,7 +3224,7 @@ A regular expression to match against the namespace of the layer surface.
 All layer surfaces have a namespace set once at creation. When this rule is non-null, the regex must match the namespace of the layer surface for this rule to match.
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.a.matches.b.at-startup -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.a.matches.b.at-startup -->
 ## `programs.niri.settings.layer-rules.*.matches.*.at-startup`
 - type: `null or boolean`
 - default: `null`
@@ -3214,7 +3232,7 @@ All layer surfaces have a namespace set once at creation. When this rule is non-
 When true, this rule will match layer surfaces opened within the first 60 seconds of niri starting up. When false, this rule will match layer surfaces opened *more than* 60 seconds after niri started up. This is useful for applying different rules to layer surfaces opened from [`spawn-at-startup`](#programsnirisettingsspawn-at-startup) versus those opened later.
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.b.excludes -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.b.excludes -->
 ## `programs.niri.settings.layer-rules.*.excludes`
 - type: `list of match rule`
 
@@ -3225,7 +3243,7 @@ If any of these rules match a layer surface, then this layer rule will not apply
 If none of these rules match a layer surface, then this layer rule will not be rejected. It will apply to that layer surface if and only if it matches one of the rules in [`layer-rules.*.matches`](#programsnirisettingslayer-rulesmatches)
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.b.excludes.a.namespace -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.b.excludes.a.namespace -->
 ## `programs.niri.settings.layer-rules.*.excludes.*.namespace`
 - type: `null or regular expression`
 - default: `null`
@@ -3235,7 +3253,7 @@ A regular expression to match against the namespace of the layer surface.
 All layer surfaces have a namespace set once at creation. When this rule is non-null, the regex must match the namespace of the layer surface for this rule to match.
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.b.excludes.b.at-startup -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.b.excludes.b.at-startup -->
 ## `programs.niri.settings.layer-rules.*.excludes.*.at-startup`
 - type: `null or boolean`
 - default: `null`
@@ -3243,7 +3261,7 @@ All layer surfaces have a namespace set once at creation. When this rule is non-
 When true, this rule will match layer surfaces opened within the first 60 seconds of niri starting up. When false, this rule will match layer surfaces opened *more than* 60 seconds after niri started up. This is useful for applying different rules to layer surfaces opened from [`spawn-at-startup`](#programsnirisettingsspawn-at-startup) versus those opened later.
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.c.block-out-from -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.c.block-out-from -->
 ## `programs.niri.settings.layer-rules.*.block-out-from`
 - type: `null or one of "screencast", "screen-capture"`
 - default: `null`
@@ -3294,7 +3312,7 @@ There are three methods of screencapture in niri:
 Essentially, use `block-out-from = "screen-capture";` if you want to be sure that the window is never visible to any external tool no matter what; or use `block-out-from = "screencast";` if you want to be able to capture screenshots of the window without its contents normally being visible in a screencast. (at the risk of some tools still leaking the window contents, see above)
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.c.opacity -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.c.opacity -->
 ## `programs.niri.settings.layer-rules.*.opacity`
 - type: `null or floating point number`
 - default: `null`
@@ -3306,7 +3324,7 @@ If the final value of this field is null, niri will fall back to a value of 1.
 Note that this is applied in addition to the opacity set by the client. Setting this to a semitransparent value on a window that is already semitransparent will make it even more transparent.
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.geometry-corner-radius -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.geometry-corner-radius -->
 ## `programs.niri.settings.layer-rules.*.geometry-corner-radius`
 - type: `null or (submodule)`
 - default: `null`
@@ -3314,54 +3332,54 @@ Note that this is applied in addition to the opacity set by the client. Setting 
 The corner radii of the surface decorations (shadow) in logical pixels.
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.geometry-corner-radius.bottom-left -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.geometry-corner-radius.bottom-left -->
 ## `programs.niri.settings.layer-rules.*.geometry-corner-radius.bottom-left`
 - type: `floating point number`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.geometry-corner-radius.bottom-right -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.geometry-corner-radius.bottom-right -->
 ## `programs.niri.settings.layer-rules.*.geometry-corner-radius.bottom-right`
 - type: `floating point number`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.geometry-corner-radius.top-left -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.geometry-corner-radius.top-left -->
 ## `programs.niri.settings.layer-rules.*.geometry-corner-radius.top-left`
 - type: `floating point number`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.geometry-corner-radius.top-right -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.geometry-corner-radius.top-right -->
 ## `programs.niri.settings.layer-rules.*.geometry-corner-radius.top-right`
 - type: `floating point number`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.shadow -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.shadow -->
 <!-- programs.niri.settings.layer-rules.*.shadow -->
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.shadow.color -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.shadow.color -->
 ## `programs.niri.settings.layer-rules.*.shadow.color`
 - type: `null or string`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.shadow.draw-behind-window -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.shadow.draw-behind-window -->
 ## `programs.niri.settings.layer-rules.*.shadow.draw-behind-window`
 - type: `null or boolean`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.shadow.enable -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.shadow.enable -->
 ## `programs.niri.settings.layer-rules.*.shadow.enable`
 - type: `null or boolean`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.shadow.inactive-color -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.shadow.inactive-color -->
 ## `programs.niri.settings.layer-rules.*.shadow.inactive-color`
 - type: `null or string`
 - default: `null`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.shadow.offset -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.shadow.offset -->
 ## `programs.niri.settings.layer-rules.*.shadow.offset`
 - type: `null or (submodule)`
 - default: `null`
@@ -3371,17 +3389,17 @@ The offset of the shadow from the window, measured in logical pixels.
 This behaves like a [CSS box-shadow offset](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#syntax)
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.shadow.offset.x -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.shadow.offset.x -->
 ## `programs.niri.settings.layer-rules.*.shadow.offset.x`
 - type: `floating point number or signed integer`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.shadow.offset.y -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.shadow.offset.y -->
 ## `programs.niri.settings.layer-rules.*.shadow.offset.y`
 - type: `floating point number or signed integer`
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.shadow.softness -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.shadow.softness -->
 ## `programs.niri.settings.layer-rules.*.shadow.softness`
 - type: `null or floating point number or signed integer`
 - default: `null`
@@ -3391,7 +3409,7 @@ The softness/size of the shadow, measured in logical pixels.
 This behaves like a [CSS box-shadow blur-radius](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#syntax)
 
 
-<!-- sorting key: programs.niri.settings.o.layer-rules.d.shadow.spread -->
+<!-- sorting key: programs.niri.settings.p.layer-rules.d.shadow.spread -->
 ## `programs.niri.settings.layer-rules.*.shadow.spread`
 - type: `null or floating point number or signed integer`
 - default: `null`
@@ -3401,7 +3419,7 @@ The spread of the shadow, measured in logical pixels.
 This behaves like a [CSS box-shadow spread radius](https://developer.mozilla.org/en-US/docs/Web/CSS/box-shadow#syntax)
 
 
-<!-- sorting key: programs.niri.settings.p.debug -->
+<!-- sorting key: programs.niri.settings.q.debug -->
 ## `programs.niri.settings.debug`
 - type: `null or (attribute set of kdl arguments)`
 - default: `null`

--- a/settings.nix
+++ b/settings.nix
@@ -1214,6 +1214,27 @@
       }
 
       {
+        overview = {
+          zoom =
+            nullable float-or-int
+            // {
+              description = ''
+                Control how much the workspaces zoom out in the overview. zoom ranges from 0 to 0.75 where lower values make everything smaller.
+              '';
+            };
+          backdrop-color =
+            nullable types.str
+            // {
+              description = ''
+                Set the backdrop color behind workspaces in the overview. The backdrop is also visible between workspaces when switching.
+
+                The alpha channel for this color will be ignored.
+              '';
+            };
+        };
+      }
+
+      {
         input = {
           keyboard = {
             xkb = let
@@ -3124,6 +3145,15 @@
 
       (leaf "screenshot-path" cfg.screenshot-path)
       (flag' "prefer-no-csd" cfg.prefer-no-csd)
+
+      (nullable plain "overview" (
+        let
+          children = lib.mapAttrsToList (nullable leaf) cfg.overview;
+        in
+          if lib.remove null children == []
+          then null
+          else children
+      ))
 
       (plain "layout" [
         (leaf "gaps" cfg.layout.gaps)


### PR DESCRIPTION
Adds support for `overview.zoom` and `overview.backdrop-color`. I tried adding support for `overview.workspace-shadow` too, but it appears that is similar to, but not exactly the same as `layout.shadow`, so would require a bit more work, and I don't have the bandwidth to do that. I only needed `overview.zoom` O:)