### PR TITLE
Move niri package configuration to `home-manager` module; reinstate `niri.homeModules.niri`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -475,7 +475,7 @@
         (nixpkgs.lib.optionalAttrs (options ? home-manager) {
           home-manager.sharedModules =
             [
-              self.homeModules.config
+              self.homeModules.niri
               {programs.niri.package = nixpkgs.lib.mkDefault cfg.package;}
             ]
             ++ nixpkgs.lib.optionals (options ? stylix) [self.homeModules.stylix];


### PR DESCRIPTION
This PR accomplishes two goals:

1. It uses the `programs.niri.package` option at the `home-manager` level to determine which version of `niri` to add to the user's environment, rather than forcing every user to use the version declared at the NixOS level.
2. It replaces `niri.homeModules.config` with `niri.homeModules.niri`, which makes it so that the claims in the README are accurate:
> When installing niri using the modules provided by this flake:
> 
>   * The niri package will be installed, including its systemd units and the niri-session binary.
>   * xdg-desktop-portal-gnome will be installed, as it is necessary for screencasting.
>   * The GNOME keyring will be enabled. You probably want a keyring installed.

Let me know if either of these are crazy things to change! I feel like the first one is pretty reasonable, and the second makes me happy because I think there should be a `home-manager` level `programs.niri.enable` option. But that's more personal preference. 
