### PR TITLE
binds: add screenshot-screen like the other binds

### DIFF
--- a/memo-binds.nix
+++ b/memo-binds.nix
@@ -14,6 +14,7 @@
   "do-screen-transition"
   "screenshot"
   "screenshot-window"
+  "screenshot-screen"
   "toggle-keyboard-shortcuts-inhibit"
   "close-window"
   "fullscreen-window"


### PR DESCRIPTION
as title suggests, currently `screenshot-screen` is the only screenshot action that has to be invoked `"foo".action.screenshot-screen = []` which leads to some confusion.