### PR TITLE
niri-flake-polkit: update for qt6

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -505,7 +505,7 @@
                 partOf = [ "graphical-session.target" ];
                 serviceConfig = {
                   Type = "simple";
-                  ExecStart = "${pkgs.libsForQt5.polkit-kde-agent}/libexec/polkit-kde-authentication-agent-1";
+                  ExecStart = "${pkgs.kdePackages.polkit-kde-agent-1}/libexec/polkit-kde-authentication-agent-1";
                   Restart = "on-failure";
                   RestartSec = 1;
                   TimeoutStopSec = 10;


### PR DESCRIPTION
Upstream nixpkgs has deleted 'libsForQt5.polkit-kde-agent' (in [this PR](https://github.com/NixOS/nixpkgs/pull/430298)).

We should also update too.

Before this:

```
$ nix flake update && nixos-rebuild switch --flake '.#'
       error: attribute 'polkit-kde-agent' missing
       at /nix/store/8zh763k2ppfhhs9zjh6anhvs4xz07gg1-source/flake.nix:508:34:
          507|                   Type = "simple";
          508|                   ExecStart = "${pkgs.libsForQt5.polkit-kde-agent}/libexec/polkit-kde-authentication-agent-1";
```

After this change, it rebuild-switches successfully, and:

```
$ systemctl status --user niri-flake-polkit.service
Active: active (running)
```

Running something that uses polkit (like `run0` or such) also pops up a shiny looking prompt, I think it looks like qt6.