### PR TITLE
backward-compatible configs for wiki and binds locations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -200,7 +200,15 @@
                 --fish <($out/bin/niri completions fish)
 
               install -Dm0644 README.md resources/default-config.kdl -t $doc/share/doc/niri
-              mv docs/wiki $doc/share/doc/niri/wiki
+
+              # The wiki location moved in Niri v25.08 from wiki/ to docs/wiki/ -
+              # check both options to support building older version
+              if [ ! -d docs/wiki ] && [ -d wiki ]; then
+                wiki_location=wiki
+              else
+                wiki_location=docs/wiki
+              fi
+              mv "$wiki_location" "$doc/share/doc/niri/wiki"
             '';
 
           postFixup = ''

--- a/settings.nix
+++ b/settings.nix
@@ -27,8 +27,18 @@
         enum
         ;
 
-      binds-stable = binds "${inputs.niri-stable}/niri-config/src/binds.rs";
-      binds-unstable = binds "${inputs.niri-unstable}/niri-config/src/binds.rs";
+      get-binds =
+        niri:
+        let
+          currentBindsSrcPath = "${niri}/niri-config/src/binds.rs";
+          legacyBindsSrcPath = "${niri}/niri-config/src/lib.rs"; # source location for binds prior to Niri v25.08
+          bindsPath =
+            if builtins.pathExists currentBindsSrcPath then currentBindsSrcPath else legacyBindsSrcPath;
+        in
+        binds bindsPath;
+
+      binds-stable = get-binds inputs.niri-stable;
+      binds-unstable = get-binds inputs.niri-unstable;
 
       record = record' null;
 


### PR DESCRIPTION
Hey, thanks for maintaining this very helpful flake! I see you got the updates in for Niri 25.08 while I was working on the same changes to get things working on my machine. I put in backward-compatible checks for the details that have changed in this version so that Niri 25.05.1 still builds. I thought that might be helpful for any flake users who have an earlier stable Niri version pinned, like I did until this morning. I'll leave it to you to decide whether these changes are worth it.

I notice that binds-stable fails for Niri v25.05.1 due to unbounded recursion in step 4 in the short-circuit in `parse-binds.nix`. I was trying to fix that, but I found that it fails the same way with or without my changes, so I decided to leave it alone.

I did test that the niri-stable output builds correctly for both 25.08 and 25.05.1 with these changes.