### PR TITLE
flake: add hydraJobs property

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -602,5 +602,7 @@
           ];
         }
       );
+
+      hydraJobs = self.packages.x86_64-linux;
     };
 }


### PR DESCRIPTION
This PR adds a `hydraJobs` property for use with a Hydra build system. With this configuration Hydra will build all the provided packages with the x86_64-linux architecture.