### PR TITLE
feat(settings): open-maximized-to-edges window rule added

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -2813,6 +2813,17 @@ If the final value of this field is null or false, then the window will not open
 If the final value of this field is true, then the window will open in a maximized column.
 
 
+## `programs.niri.settings.window-rules.*.open-maximized-to-edges`
+- type: `null or boolean`
+- default: `null`
+
+Whether to open this window maximized to the screen edges.
+
+If the final value of this field is null or false, then the window will not open maximized to edges.
+
+If the final value of this field is true, then the window will open maximized to edges.
+
+
 ## `programs.niri.settings.window-rules.*.open-on-output`
 - type: `null or string`
 - default: `null`

--- a/settings.nix
+++ b/settings.nix
@@ -2638,6 +2638,15 @@
                         If the final value of this field is true, then the window will open in a maximized column.
                       '';
                     };
+                    open-maximized-to-edges = nullable types.bool // {
+                      description = ''
+                        Whether to open this window maximized to the screen edges.
+
+                        If the final value of this field is null or false, then the window will not open maximized to edges.
+
+                        If the final value of this field is true, then the window will open maximized to edges.
+                      '';
+                    };
                     open-fullscreen = nullable types.bool // {
                       description = ''
                         Whether to open this window in fullscreen.
@@ -3703,6 +3712,7 @@
             (nullable leaf "open-on-output" cfg.open-on-output)
             (nullable leaf "open-on-workspace" cfg.open-on-workspace)
             (nullable leaf "open-maximized" cfg.open-maximized)
+            (nullable leaf "open-maximized-to-edges" cfg.open-maximized-to-edges)
             (nullable leaf "open-fullscreen" cfg.open-fullscreen)
             (nullable leaf "open-floating" cfg.open-floating)
             (nullable leaf "open-focused" cfg.open-focused)


### PR DESCRIPTION
Added support for `open-maximized-to-edges` window rule.

https://yalter.github.io/niri/Fullscreen-and-Maximize.html#windows-maximized-to-edges
https://github.com/YaLTeR/niri/pull/2376