### PR TITLE
use soteria instead of kde-polkit-agent as its a lot faster

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -495,20 +495,8 @@
               };
 
               security.polkit.enable = true;
+              security.soteria.enable = true;
               services.gnome.gnome-keyring.enable = true;
-              systemd.user.services.niri-flake-polkit = {
-                description = "PolicyKit Authentication Agent provided by niri-flake";
-                wantedBy = [ "niri.service" ];
-                after = [ "graphical-session.target" ];
-                partOf = [ "graphical-session.target" ];
-                serviceConfig = {
-                  Type = "simple";
-                  ExecStart = "${pkgs.kdePackages.polkit-kde-agent-1}/libexec/polkit-kde-authentication-agent-1";
-                  Restart = "on-failure";
-                  RestartSec = 1;
-                  TimeoutStopSec = 10;
-                };
-              };
 
               security.pam.services.swaylock = { };
               programs.dconf.enable = nixpkgs.lib.mkDefault true;


### PR DESCRIPTION
Rational: currently the niri-flake-polkit is **very** slow to respond (multiple seconds usually). you also mentioned that you eventually want to retire the unit completely, which is sane.
Soteria is maintained by upstream nixpkgs and switching to it should not cause any breakage (apart from maybe some window rules).