### PR TITLE
Add niri-flake.homeManagerIntegration.autoImport option

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -463,6 +463,13 @@
             default = true;
           };
 
+          options.niri-flake.homeManagerIntegration.autoImport = nixpkgs.lib.mkOption {
+            description = "Whether Home Manager modules should be autmatically imported.";
+            type = nixpkgs.lib.types.bool;
+            default = true;
+            example = false;
+          };
+
           config = nixpkgs.lib.mkMerge [
             (nixpkgs.lib.mkIf config.niri-flake.cache.enable {
               nix.settings = {
@@ -514,13 +521,16 @@
               programs.dconf.enable = nixpkgs.lib.mkDefault true;
               fonts.enableDefaultPackages = nixpkgs.lib.mkDefault true;
             })
-            (nixpkgs.lib.optionalAttrs (options ? home-manager) {
-              home-manager.sharedModules = [
-                self.homeModules.config
-                { programs.niri.package = nixpkgs.lib.mkForce cfg.package; }
-              ]
-              ++ nixpkgs.lib.optionals (options ? stylix) [ self.homeModules.stylix ];
-            })
+
+            (nixpkgs.lib.optionalAttrs (options ? home-manager) (
+              nixpkgs.lib.mkIf config.niri-flake.homeManagerIntegration.autoImport {
+                home-manager.sharedModules = [
+                  self.homeModules.config
+                  { programs.niri.package = nixpkgs.lib.mkForce cfg.package; }
+                ]
+                ++ nixpkgs.lib.optionals (options ? stylix) [ self.homeModules.stylix ];
+              }
+            ))
           ];
         };
       homeModules.niri =


### PR DESCRIPTION
This PR introduces an option to conditionally import Home Manager modules when the NixOS module is imported.

Option syntax and behavior follow the one we can find in Stylix:
https://nix-community.github.io/stylix/options/platforms/nixos.html#stylixhomemanagerintegrationautoimport
https://github.com/nix-community/stylix/blob/ddc49fd564a599474d6587df25553cbfd7325ece/stylix/home-manager-integration.nix#L196

Such a feature is useful in cases where configuration is reused between standalone and NixOS-based Home Manager setups. This, by incredible coincidence, tends to be my case. To load the same Home Manager module in both setups, I either have to conditionally import nix-flake provided modules (which fails due to infinite recursion), import them twice (which fails due to declaring the same option twice), or apply this setting.

```nix
{ inputs, ... }:
{
  flake.nixosModules.window-manager = {
    imports = [
      inputs.niri.nixosModules.niri
    ];
    niri-flake.homeManagerIntegration.autoImport = false;
    programs.niri = {
      enable = true;
    };
    # ... #
  };
  flake.homeModules.window-manager =
    {
      imports = [
        inputs.niri.homeModules.niri
        inputs.niri.homeModules.stylix
      ];
      programs.niri = {
        # ... #
      };
}
```