### PR TITLE
add default attribute for overlays and NixOS and home-manager modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -375,6 +375,7 @@
       packages = forAllSystems (system: make-package-set inputs.nixpkgs.legacyPackages.${system});
 
       overlays.niri = final: prev: make-package-set final;
+      overlays.default = self.overlays.niri;
 
       apps = forAllSystems (
         system:


### PR DESCRIPTION
Add `default` attribute for overlays and NixOS and home-manager modules.