### PR TITLE
append the cache URL at the end of substituters

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -466,7 +466,7 @@
           config = nixpkgs.lib.mkMerge [
             (nixpkgs.lib.mkIf config.niri-flake.cache.enable {
               nix.settings = {
-                substituters = [ "https://niri.cachix.org" ];
+                substituters = nixpkgs.lib.mkAfter [ "https://niri.cachix.org" ];
                 trusted-public-keys = [ "niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964=" ];
               };
             })


### PR DESCRIPTION
simply declaring `substituters = [ "https://niri.cachix.org" ]` in nix configuration makes it append all other substituters at the end, which results in `nix.conf` containing:
```conf
substituters = https://niri.cachix.org https://cache.nixos.org
```

i consider this to be an issue because the order of substituters matters, and this forces nix to always query `https://niri.cachix.org` first, which may not be desired.

this pr simply uses `lib.mkAfter` to fix that.
