### PR TITLE
change niri url to niri-wm/niri

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This flake contains nix packages for [niri](https://github.com/YaLTeR/niri), a scrollable-tiling Wayland compositor. You can try it right now: add the binary cache with `cachix use niri` and then `nix run github:sodiboo/niri-flake`. You can also try the latest commit to the `main` branch with `nix run github:sodiboo/niri-flake#niri-unstable`.
+This flake contains nix packages for [niri](https://github.com/niri-wm/niri), a scrollable-tiling Wayland compositor. You can try it right now: add the binary cache with `cachix use niri` and then `nix run github:sodiboo/niri-flake`. You can also try the latest commit to the `main` branch with `nix run github:sodiboo/niri-flake#niri-unstable`.
 
 This flake also contains NixOS and home-manager modules to install all necessary components of a working Wayland environment, and to let you manage your configuration declaratively, validating it at build-time. This ensures that your config's schema is always in sync with the installed version of niri.
 

--- a/docs.md
+++ b/docs.md
@@ -15,7 +15,7 @@ You should preferably not be using these outputs directly. Instead, you should u
 
 The latest stable tagged version of niri, along with potential patches.
 
-Currently, this is release [`25.08`](https://github.com/YaLTeR/niri/releases/tag/25.08) with no additional patches.
+Currently, this is release [`25.08`](https://github.com/niri-wm/niri/releases/tag/25.08) with no additional patches.
 
 
 
@@ -28,7 +28,7 @@ To access this package under `pkgs.niri-stable`, you should use [`overlays.niri`
 
 The latest commit to the development branch of niri.
 
-Currently, this is exactly commit [`549148d`](https://github.com/YaLTeR/niri/tree/549148d27779d024255a84535b42b947f1c2a113) which was authored on `2026-02-06 16:22:16`.
+Currently, this is exactly commit [`549148d`](https://github.com/niri-wm/niri/tree/549148d27779d024255a84535b42b947f1c2a113) which was authored on `2026-02-06 16:22:16`.
 
 > [!warning]
 > `niri-unstable` is not a released version, there are no stability guarantees, and it may break your workflow from itme to time.
@@ -1745,7 +1745,7 @@ the bottom edge of the big window is almost entirely yellow, and the top edge of
 ](/assets/relative-to-workspace-view.png "behaviour of relative-to=\"workspace-view\"")
 
 
-these beautiful images are sourced from the release notes for [`v0.1.3`](https://github.com/YaLTeR/niri/releases/tag/v0.1.3)
+these beautiful images are sourced from the release notes for [`v0.1.3`](https://github.com/niri-wm/niri/releases/tag/v0.1.3)
 
 
 ## `<decoration>.gradient.to`
@@ -2092,7 +2092,7 @@ Source code for a GLSL shader to use for this animation.
 
 For example, set it to `builtins.readFile ./window-close.glsl` to use a shader from the same directory as your configuration file.
 
-See: https://github.com/YaLTeR/niri/wiki/Configuration:-Animations#custom-shader
+See: https://github.com/niri-wm/niri/wiki/Configuration:-Animations#custom-shader
 
 
 ## `programs.niri.settings.animations.window-close.enable`
@@ -2127,7 +2127,7 @@ Source code for a GLSL shader to use for this animation.
 
 For example, set it to `builtins.readFile ./window-open.glsl` to use a shader from the same directory as your configuration file.
 
-See: https://github.com/YaLTeR/niri/wiki/Configuration:-Animations#custom-shader
+See: https://github.com/niri-wm/niri/wiki/Configuration:-Animations#custom-shader
 
 
 ## `programs.niri.settings.animations.window-open.enable`
@@ -2150,7 +2150,7 @@ Source code for a GLSL shader to use for this animation.
 
 For example, set it to `builtins.readFile ./window-resize.glsl` to use a shader from the same directory as your configuration file.
 
-See: https://github.com/YaLTeR/niri/wiki/Configuration:-Animations#custom-shader
+See: https://github.com/niri-wm/niri/wiki/Configuration:-Animations#custom-shader
 
 
 ## `programs.niri.settings.animations.window-resize.enable`

--- a/fetch-refs.nix
+++ b/fetch-refs.nix
@@ -45,7 +45,7 @@ in
   # This is because commit hashes are globally unique.
   {
     # niri
-    ${fetch "YaLTeR/niri"}
+    ${fetch "niri-wm/niri"}
     # xwayland-satellite
     ${fetch "Supreeeme/xwayland-satellite"}
   }

--- a/flake.lock
+++ b/flake.lock
@@ -5,13 +5,13 @@
       "locked": {
         "lastModified": 1756556321,
         "narHash": "sha256-RLD89dfjN0RVO86C/Mot0T7aduCygPGaYbog566F0Qo=",
-        "owner": "YaLTeR",
+        "owner": "niri-wm",
         "repo": "niri",
         "rev": "01be0e65f4eb91a9cd624ac0b76aaeab765c7294",
         "type": "github"
       },
       "original": {
-        "owner": "YaLTeR",
+        "owner": "niri-wm",
         "ref": "v25.08",
         "repo": "niri",
         "type": "github"
@@ -22,13 +22,13 @@
       "locked": {
         "lastModified": 1770394936,
         "narHash": "sha256-Pa0fkyLYUR+pZh7phPENDUo4mJIweaAm0uV83iUUlX8=",
-        "owner": "YaLTeR",
+        "owner": "niri-wm",
         "repo": "niri",
         "rev": "549148d27779d024255a84535b42b947f1c2a113",
         "type": "github"
       },
       "original": {
-        "owner": "YaLTeR",
+        "owner": "niri-wm",
         "repo": "niri",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-25.11";
 
-    niri-stable.url = "github:YaLTeR/niri/v25.08";
-    niri-unstable.url = "github:YaLTeR/niri";
+    niri-stable.url = "github:niri-wm/niri/v25.08";
+    niri-unstable.url = "github:niri-wm/niri";
 
     xwayland-satellite-stable.url = "github:Supreeeme/xwayland-satellite/v0.7";
     xwayland-satellite-unstable.url = "github:Supreeeme/xwayland-satellite";
@@ -220,7 +220,7 @@
 
           meta = {
             description = "Scrollable-tiling Wayland compositor";
-            homepage = "https://github.com/YaLTeR/niri";
+            homepage = "https://github.com/niri-wm/niri";
             license = nixpkgs.lib.licenses.gpl3Only;
             maintainers = with nixpkgs.lib.maintainers; [ sodiboo ];
             mainProgram = "niri";

--- a/generate-docs.nix
+++ b/generate-docs.nix
@@ -109,9 +109,9 @@ let
       rev,
       shortRev,
     }:
-    "[`${shortRev}`](https://github.com/YaLTeR/niri/tree/${rev})";
+    "[`${shortRev}`](https://github.com/niri-wm/niri/tree/${rev})";
   link-niri-release =
-    version: "[`${version}`](https://github.com/YaLTeR/niri/releases/tag/${version})";
+    version: "[`${version}`](https://github.com/niri-wm/niri/releases/tag/${version})";
 
   link-stylix-opt = opt: "[`${opt}`](https://danth.github.io/stylix/options/hm.html#${anchor opt})";
 

--- a/settings.nix
+++ b/settings.nix
@@ -113,7 +113,7 @@
       link-niri-release =
         version:
         fmt.masked-link {
-          href = "https://github.com/YaLTeR/niri/releases/tag/${version}";
+          href = "https://github.com/niri-wm/niri/releases/tag/${version}";
           content = fmt.code version;
         };
 
@@ -2309,7 +2309,7 @@
 
                               For example, set it to ${fmt.code "builtins.readFile ./${name}.glsl"} to use a shader from the same directory as your configuration file.
 
-                              See: ${fmt.bare-link "https://github.com/YaLTeR/niri/wiki/Configuration:-Animations#custom-shader"}
+                              See: ${fmt.bare-link "https://github.com/niri-wm/niri/wiki/Configuration:-Animations#custom-shader"}
                             '';
                           };
                         }
@@ -3122,7 +3122,7 @@
             builtins.concatMap (
               patch:
               let
-                m = lib.strings.match "${lib.escapeRegex "https://github.com/YaLTeR/niri/commit/"}([0-9a-f]{40})${lib.escapeRegex ".patch"}" patch.url;
+                m = lib.strings.match "${lib.escapeRegex "https://github.com/niri-wm/niri/commit/"}([0-9a-f]{40})${lib.escapeRegex ".patch"}" patch.url;
               in
               if m != null then
                 [


### PR DESCRIPTION
They moved the project to this organization, so I ran a sed command making the changes here. This should be the same version of the project that the flake.lock was at before.