### PR TITLE
Feat/select hot corners

### DIFF
--- a/settings.nix
+++ b/settings.nix
@@ -799,6 +799,20 @@
           '';
         };
 
+      hot-corners-definition =
+        section {
+          enable = optional types.bool true // {
+            description = "Set to false to disable hot corners.";
+          };
+          selection = nullable (listOf types.str) // {
+            description = "Subset of top-left, top-right, bottom-left, bottom-right.";
+          };
+        } // {
+        description = ''
+          Put your mouse at a corner of a monitor to toggle the overview. Also works during drag-and-dropping something.
+        '';
+      };
+
       alphabetize =
         sections:
         lib.mergeAttrsList (
@@ -1915,19 +1929,7 @@
                 '';
               };
 
-              hot-corners =
-                  section {
-                    enable = optional types.bool true // {
-                      description = "Set to false to disable hot corners.";
-                    };
-                    selection = nullable (listOf types.str) // {
-                      description = "Subset of top-left, top-right, bottom-left, bottom-right.";
-                    };
-                  } // {
-                  description = ''
-                    Put your mouse at a corner of a monitor to toggle the overview. Also works during drag-and-dropping something.
-                  '';
-                };
+              hot-corners = hot-corners-definition;
             });
           }
 
@@ -2452,19 +2454,7 @@
                       This does not happen when the overview is not open.
                     '';
                   };
-                hot-corners =
-                  section {
-                    enable = optional types.bool true // {
-                      description = "Set to false to disable hot corners.";
-                    };
-                    selection = optional (listOf types.str) [ "top-left" ] // {
-                      description = "Subset of top-left, top-right, bottom-left, bottom-right.";
-                    };
-                  } // {
-                  description = ''
-                    Put your mouse at a corner of a monitor to toggle the overview. Also works during drag-and-dropping something.
-                  '';
-                };
+                hot-corners = hot-corners-definition;
               };
           }
 
@@ -3789,7 +3779,9 @@
             (nullable leaf "delay-ms" cfg.gestures.dnd-edge-workspace-switch.delay-ms)
             (nullable leaf "max-speed" cfg.gestures.dnd-edge-workspace-switch.max-speed)
           ])
-          (plain' "hot-corners" (toggle "off" cfg.gestures.hot-corners [(each cfg.gestures.hot-corners.selection flag)]))
+          (optional-node (cfg.gestures.hot-corners.enable == false || cfg.gestures.hot-corners.selection != null) (
+            plain' "hot-corners" (toggle "off" cfg.gestures.hot-corners [(each cfg.gestures.hot-corners.selection flag)])
+          ))
         ])
 
         (plain' "animations" [


### PR DESCRIPTION
- select active hot corners in `gestures`
- select active hot corners per `output`
- unified "type def" for both
- respective kdl section hidden by default, so that niri's defaults apply

example
```nix
programs.niri.settings = {
    gestures.hot-corners.selection = [ "bottom-left" "bottom-right" ];

    outputs."some-2nd-ary-monitor" = {
      hot-corners.enable = false;
    };

    ...
```