### PR TITLE
settings: add recent-windows-close animation

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -2070,6 +2070,18 @@ The left and right structs work in a similar way, except the padded space is not
 - default: `null`
 
 
+<!-- programs.niri.settings.animations.recent-windows-close -->
+
+## `programs.niri.settings.animations.recent-windows-close.enable`
+- type: `boolean`
+- default: `true`
+
+
+## `programs.niri.settings.animations.recent-windows-close.kind`
+- type: `null or`[`<animation-kind>`](#animation-kind)
+- default: `null`
+
+
 <!-- programs.niri.settings.animations.screenshot-ui-open -->
 
 ## `programs.niri.settings.animations.screenshot-ui-open.enable`

--- a/settings.nix
+++ b/settings.nix
@@ -2271,6 +2271,7 @@
                   window-movement.has-shader = false;
                   window-open.has-shader = true;
                   window-close.has-shader = true;
+                  recent-windows-close.has-shader = false;
                   window-resize.has-shader = true;
                   screenshot-ui-open.has-shader = false;
                   overview-open-close.has-shader = false;


### PR DESCRIPTION
## What

Adds the `recent-windows-close` animation slot to `programs.niri.settings.animations`.

## Why

niri gained the `recent-windows-close` animation in v25.11 (the alt-tab / recent-windows switcher overlay), but the generated settings module never exposed it, so it could not be configured through `programs.niri.settings.animations` — setting it raised `The option ... does not exist`.

## Details

- Added `recent-windows-close.has-shader = false;` to the `anims` set in `settings.nix`. Per niri source, `RecentWindowsCloseAnim` is a plain `Animation` newtype with no `custom_shader` field, unlike `window-open`/`window-close`, hence `has-shader = false`.
- Regenerated `docs.md`.

Safe for the pinned stable (v25.08, which predates the slot): the renderer (`plain'`) only emits a node when a child value is non-null, so an unconfigured `recent-windows-close` emits no KDL. Only users who explicitly set it (on niri >= v25.11) produce output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
