### PR TITLE
fix: remove obsolete libdisplay-info_0_2 reference

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,6 @@
           seatd,
           libinput,
           libxkbcommon,
-          libdisplay-info_0_2 ? libdisplay-info,
           libdisplay-info,
           pango,
           withDbus ? true,
@@ -100,7 +99,6 @@
           # remove param at next release after 25.11 (yes! i know that's not even the stable version provided by this flake right now. i'm Working On It™)
           replace-service-with-usr-bin,
         }:
-        assert libdisplay-info_0_2.version == "0.2.0";
         rustPlatform.buildRustPackage {
           pname = "niri";
           version = package-version src;
@@ -122,7 +120,7 @@
             libglvnd
             seatd
             libinput
-            libdisplay-info_0_2
+            libdisplay-info
             libxkbcommon
             pango
           ]


### PR DESCRIPTION
## Summary
Nixpkgs recently removed the deprecated `libdisplay-info_0_2` package alias. This PR removes the obsolete `libdisplay-info_0_2` parameter, assertion, and build input from `flake.nix` in favor of `libdisplay-info`.