### PR TITLE
fix(flake): use libdisplay-info_0_3 (replaces removed libdisplay-info_0_2)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785828668,
-        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,7 +87,7 @@
           seatd,
           libinput,
           libxkbcommon,
-          libdisplay-info_0_2 ? libdisplay-info,
+          libdisplay-info_0_3 ? libdisplay-info,
           libdisplay-info,
           pango,
           withDbus ? true,
@@ -100,7 +100,6 @@
           # remove param at next release after 25.11 (yes! i know that's not even the stable version provided by this flake right now. i'm Working On It™)
           replace-service-with-usr-bin,
         }:
-        assert libdisplay-info_0_2.version == "0.2.0";
         rustPlatform.buildRustPackage {
           pname = "niri";
           version = package-version src;
@@ -122,7 +121,7 @@
             libglvnd
             seatd
             libinput
-            libdisplay-info_0_2
+            libdisplay-info_0_3
             libxkbcommon
             pango
           ]


### PR DESCRIPTION
nixpkgs recently removed `libdisplay-info_0_2`. As pointed out by @thuiop and per [niri-wm/niri#4366](https://github.com/niri-wm/niri/pull/4366), niri now requires `libdisplay-info_0_3`.

This updates the dependency from the removed `libdisplay-info_0_2` to `libdisplay-info_0_3` so builds don't fail when evaluating against current nixpkgs unstable.

Fixes #1851