### PR TITLE
Fix busted build: select libdisplay-info to match each niri source's Cargo.lock

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -28,7 +28,7 @@ To access this package under `pkgs.niri-stable`, you should use [`overlays.niri`
 
 The latest commit to the development branch of niri.
 
-Currently, this is exactly commit [`feb3e43`](https://github.com/YaLTeR/niri/tree/feb3e43f1475e0865bb89cbd1e898b34d1d2ccf6) which was authored on `2026-08-02 20:07:21`.
+Currently, this is exactly commit [`0add05d`](https://github.com/YaLTeR/niri/tree/0add05dde70df3c6d70362913aa007fac4c31f91) which was authored on `2026-08-11 11:39:51`.
 
 > [!warning]
 > `niri-unstable` is not a released version, there are no stability guarantees, and it may break your workflow from itme to time.

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1785701241,
-        "narHash": "sha256-ircVOzPWRircI39ac/tqJajr5OoJxEVrDlBb05TULEk=",
+        "lastModified": 1786448391,
+        "narHash": "sha256-6zc5pJIIql0P2gba9lkmrV685gAllv2e9GEn7B9R53I=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "feb3e43f1475e0865bb89cbd1e898b34d1d2ccf6",
+        "rev": "0add05dde70df3c6d70362913aa007fac4c31f91",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785828668,
-        "narHash": "sha256-8fsyqeO+mJqvIzeO4xIpgJe/f7MTbbVTEC6RT6WSXNs=",
+        "lastModified": 1786247143,
+        "narHash": "sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e72e4f299401a3689d4b3d5fc6496b11db7064eb",
+        "rev": "279b4a8275f032c566576b3f181fa0f27197f588",
         "type": "github"
       },
       "original": {
@@ -95,11 +95,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1784679892,
-        "narHash": "sha256-Mb7jpqnrcYCfNSItIkkHpuR3YxWFxPuIBfcwNKlRBkk=",
+        "lastModified": 1786221058,
+        "narHash": "sha256-hF2atQzapHBLX5NFqJMcKZAWHfGkKQeNu1eQr46+AGg=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "8d135d3b2854b30fd01ea6cd6c27e523dd50a839",
+        "rev": "3bc915f09dd62bb2651a715114f9d140344bc6c1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,8 +87,10 @@
           seatd,
           libinput,
           libxkbcommon,
-          libdisplay-info_0_2 ? libdisplay-info,
+          # absent on nixos-25.11, where the default is already 0.3
+          libdisplay-info_0_3 ? libdisplay-info,
           libdisplay-info,
+          fetchFromGitLab,
           pango,
           withDbus ? true,
           withDinit ? false,
@@ -100,7 +102,35 @@
           # remove param at next release after 25.11 (yes! i know that's not even the stable version provided by this flake right now. i'm Working On It™)
           replace-service-with-usr-bin,
         }:
-        assert libdisplay-info_0_2.version == "0.2.0";
+        let
+          inherit (nixpkgs.lib.versions) majorMinor;
+
+          # the libdisplay-info crate only links against a system library of the same major.minor
+          libdisplay-info-crate =
+            nixpkgs.lib.findFirst (p: p.name == "libdisplay-info")
+              (throw "no libdisplay-info in ${src}/Cargo.lock")
+              (builtins.fromTOML (builtins.readFile "${src}/Cargo.lock")).package;
+
+          libdisplay-info-matching =
+            {
+              # removed from nixpkgs, so rebuild it from the current recipe
+              "0.2" = libdisplay-info.overrideAttrs {
+                version = "0.2.0";
+                src = fetchFromGitLab {
+                  domain = "gitlab.freedesktop.org";
+                  owner = "emersion";
+                  repo = "libdisplay-info";
+                  rev = "0.2.0";
+                  hash = "sha256-6xmWBrPHghjok43eIDGeshpUEQTuwWLXNHg7CnBUt3Q=";
+                };
+              };
+              "0.3" = libdisplay-info_0_3;
+            }
+            .${majorMinor libdisplay-info-crate.version} or libdisplay-info;
+        in
+        assert nixpkgs.lib.assertMsg
+          (majorMinor libdisplay-info-matching.version == majorMinor libdisplay-info-crate.version)
+          "niri needs libdisplay-info ${majorMinor libdisplay-info-crate.version}, but nixpkgs provides ${libdisplay-info-matching.version}";
         rustPlatform.buildRustPackage {
           pname = "niri";
           version = package-version src;
@@ -122,7 +152,7 @@
             libglvnd
             seatd
             libinput
-            libdisplay-info_0_2
+            libdisplay-info-matching
             libxkbcommon
             pango
           ]


### PR DESCRIPTION
Verified: both packages build; `nix flake check` and docs eval pass against nixos-unstable and nixos-25.11 package sets.